### PR TITLE
[Night-3] Grzywka combustor, staged mission wiring, movable inlet, stability reconciliation

### DIFF
--- a/agents/memory.md
+++ b/agents/memory.md
@@ -49,6 +49,22 @@ Append-only; maintained by the orchestrator.
   blocker (needs human input or design decision). Conflating the two in
   `analysis_status.md` would cause the next session to waste time
   re-diagnosing a phase that was simply cut short.
+
+## Night-3 STEP-0 (2026-07-09)
+- Baseline: 80/80 green (after installing missing runtime deps in fresh
+  container: `pytest`, `pydantic`, `pyyaml`, `scipy`, `numpy` — none were
+  preinstalled; `analyses/propulsion/inlet_performance.py` imports
+  `scipy.optimize`, so scipy is a hard runtime dep despite not being listed
+  in CLAUDE.md's "dev deps" note).
+- Blocked phases to resume: 2b (combustor_nozzle_cycle.py), 3b (staged
+  mission cruise wiring), 4b (movable inlet actuation).
+- Active assumptions: A1-A16 tracked in docs/assumptions.md.
+- Known urgent items: fin span sign flip (SM +8.99 cal Barrowman vs
+  -2.75 cal Teltik CFD at Ma 2.5 — HUMAN_REVIEW, do not resolve
+  unilaterally), Grzywka combustor/nozzle model (2b), actuator params (4b).
+- Working branch for this session: `claude/dazzling-turing-d91coa` (harness
+  -assigned; did not create a separate night3-suffix branch per harness
+  branch policy).
 - **A checkpoint is a tracker section with the full resume spec, not just a
   status flag.** "BLOCKED_BY_BUDGET" alone tells the next session nothing
   about what to do; the checkpoint must carry the complete task spec (files

--- a/analyses/cfd/su2_config_template.py
+++ b/analyses/cfd/su2_config_template.py
@@ -1,33 +1,114 @@
-# MELprop-IADE | analyses.cfd.su2_config_template | v0.1.0
-"""SU2 external-aerodynamics configuration-template stub.
+# MELprop-IADE | analyses.cfd.su2_config_template | v0.2.0
+"""SU2 external-aerodynamics configuration generator for the ramjet rocket.
 
-Generates SU2 ``.cfg`` files for an inviscid/RANS Mach sweep of the
-ramjet rocket to extract CL/CD across the transonic–supersonic envelope,
-complementing the low-order Barrowman (stability) and DATCOM-style drag
-estimates used elsewhere in the project.
+Generates SU2 ``.cfg`` files for an inviscid (Euler) Mach sweep of the
+ramjet rocket, to extract CL/CD/Cm across the transonic-supersonic
+envelope. This is the escalation path beyond AVL for Project B: AVL
+(vortex-lattice) is only valid for Mach < 0.6 and |alpha| < 15 deg
+(project rule #7 / ``analyses/aerodynamics/avl_wrapper.py``), so the
+whole :data:`MACH_SWEEP` here (0.8-3.0) sits outside AVL's envelope and
+is instead handled with SU2's compressible Euler solver, complementing
+the Barrowman/DATCOM-style empirical drag estimates used elsewhere.
 
-Workflow (to be implemented):
-    1. Mesh generation with gmsh from the axisymmetric body + fins.
-    2. SU2_CFD run per Mach number (Euler first, then RANS/SA).
-    3. Force-coefficient extraction (CL, CD, Cm) from the SU2 history.
+IMPORTANT -- this module only *writes* SU2 configuration text files. It
+never invokes ``su2_CFD``, ``gmsh``, or any other external binary: none
+of those are installed in this environment (see ``doc/AGENT_CONTEXT.md``
+Section 3). Every generated file carries a ``# TO RUN: su2_CFD
+<file>.cfg`` comment so a human (or a future CI job with SU2 installed)
+knows how to actually execute it, plus the ``MESH_FILENAME`` a
+corresponding gmsh run must produce first.
+
+Geometry (body length/diameter, fin span/chord) is read from the
+committed vehicle config (``vehicles/ramjet_rocket/vehicle_config.yaml``)
+via :class:`~src.schemas.vehicle_schema.RocketConfig` -- it is never
+hard-coded here, so the generated decks stay in sync with the vehicle
+definition. Freestream conditions use the same ICAO troposphere formula
+as ``analyses/trajectory/booster_burnout.py`` (:func:`isa_atmosphere`
+below), evaluated at the ramjet design altitude
+(``analyses.propulsion.inlet_performance.DESIGN_ALTITUDE_M``, 10,000 m).
+The formula is re-implemented locally (instead of importing
+``booster_burnout``) to avoid pulling that module's ``matplotlib``
+plotting dependency into a plain ``.cfg``-file generator.
+
+Workflow (to be completed once SU2/gmsh are available in a container):
+    1. Mesh generation with gmsh from the axisymmetric body + fins
+       (``MESH_FILENAME`` in each generated config is the expected
+       gmsh output; not produced by this module).
+    2. ``su2_CFD <file>.cfg`` per Mach number (Euler first, then
+       RANS/SA if viscous drag corroboration is needed).
+    3. Force-coefficient extraction (CL, CD, Cm) from the SU2 history
+       file for a drag-polar table consumed by the trajectory workflow.
 
 Theory / tooling reference:
     Economon, T. D. et al., "SU2: An Open-Source Suite for Multiphysics
     Simulation and Design", AIAA Journal 54(3), 2016.
-
-TODO:
-    * gmsh geometry + boundary-layer mesh generation.
-    * Per-Mach farfield boundary conditions (ISA at design altitude).
-    * Launch SU2_CFD, monitor convergence, parse forces.
-    * Aggregate CL(M), CD(M) into a drag-polar table for trajectory use.
 """
 
 from __future__ import annotations
 
-#: Mach numbers swept for the external-aero study.
-MACH_SWEEP: tuple[float, ...] = (0.8, 1.2, 1.5, 2.0, 2.5, 3.0)
+import math
+import sys
+from pathlib import Path
 
-#: SU2 config keys common to every Mach case (template defaults).
+if __package__ in (None, ""):
+    sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from analyses.propulsion.inlet_performance import DESIGN_ALTITUDE_M
+from core.component_base import AnalysisResults, BaseAnalysis, FidelityLevel
+from src.schemas.vehicle_schema import BaseVehicleConfig, RocketConfig
+
+#: Mach numbers swept for the external-aero study (transonic -> Mach 3,
+#: i.e. entirely above the AVL applicability ceiling of Mach 0.6).
+MACH_SWEEP: tuple[float, ...] = (0.8, 1.5, 2.0, 2.5, 3.0)
+
+#: ISA sea-level standard temperature [K] (ICAO Doc 7488).
+_T0_ISA_K: float = 288.15
+#: ISA sea-level standard pressure [Pa] (ICAO Doc 7488).
+_P0_ISA_PA: float = 101325.0
+#: ISA troposphere lapse rate [K/m] (0 <= h < 11000 m).
+_LAPSE_RATE_K_PER_M: float = 0.0065
+#: Specific gas constant for dry air [J/(kg*K)].
+_R_AIR_J_PER_KGK: float = 287.05
+#: Gravitational acceleration [m/s^2].
+_G0_MS2: float = 9.80665
+#: ISA troposphere pressure-altitude exponent, g0 / (lapse_rate * R_air).
+_ISA_PRESSURE_EXPONENT: float = _G0_MS2 / (_LAPSE_RATE_K_PER_M * _R_AIR_J_PER_KGK)
+
+
+def isa_atmosphere(altitude_m: float) -> tuple[float, float, float]:
+    """Evaluate the ICAO standard atmosphere in the troposphere layer.
+
+    Re-implements the same troposphere formula used by
+    ``analyses/trajectory/booster_burnout.py::isa_atmosphere`` (kept
+    local here to avoid importing that module's ``matplotlib``
+    plotting dependency for a plain ``.cfg``-file generator).
+
+    Args:
+        altitude_m: Geometric altitude [m]. Clamped to ``>= 0``.
+
+    Returns:
+        Tuple ``(temperature_K, pressure_Pa, density_kg_m3)``.
+    """
+    h = max(altitude_m, 0.0)
+    temperature_K = _T0_ISA_K - _LAPSE_RATE_K_PER_M * h
+    pressure_Pa = _P0_ISA_PA * (temperature_K / _T0_ISA_K) ** _ISA_PRESSURE_EXPONENT
+    density_kg_m3 = pressure_Pa / (_R_AIR_J_PER_KGK * temperature_K)
+    return temperature_K, pressure_Pa, density_kg_m3
+
+#: Repository root, resolved from this file's location.
+REPO_ROOT: Path = Path(__file__).resolve().parents[2]
+
+#: Default vehicle config this generator reads geometry from.
+VEHICLE_CONFIG_PATH: Path = (
+    REPO_ROOT / "vehicles" / "ramjet_rocket" / "vehicle_config.yaml"
+)
+
+#: Directory the generated ``.cfg`` files are written into (next to this
+#: module, mirroring the output-path convention used by the other
+#: ``analyses/`` modules, e.g. ``analyses/stability/*.json``).
+OUTPUT_DIR: Path = Path(__file__).resolve().parent / "su2_configs"
+
+#: SU2 config keys common to every Mach case (Euler, no viscous terms).
 _BASE_CONFIG: dict[str, str] = {
     "SOLVER": "EULER",
     "MATH_PROBLEM": "DIRECT",
@@ -35,43 +116,328 @@ _BASE_CONFIG: dict[str, str] = {
     "MARKER_EULER": "( airframe )",
     "MARKER_FAR": "( farfield )",
     "CONV_NUM_METHOD_FLOW": "JST",
+    "NUM_METHOD_GRAD": "WEIGHTED_LEAST_SQUARES",
+    "CFL_NUMBER": "5.0",
+    "CONV_CRITERIA": "RESIDUAL",
+    "CONV_RESIDUAL_MINVAL": "-8",
     "ITER": "5000",
+    "OUTPUT_FILES": "(RESTART, PARAVIEW, SURFACE_CSV)",
+    "HISTORY_OUTPUT": "(ITER, RMS_RES, AERO_COEFF)",
 }
 
 
-def build_su2_config(mach: float, aoa_deg: float = 0.0) -> str:
-    """Render an SU2 ``.cfg`` text for one Mach/AoA case.
+def load_rocket_config(path: Path | str = VEHICLE_CONFIG_PATH) -> RocketConfig:
+    """Load and validate the ramjet-rocket vehicle configuration.
+
+    Args:
+        path: Path to a ``vehicle_config.yaml`` for Project B.
+
+    Returns:
+        Validated :class:`RocketConfig`.
+
+    Raises:
+        TypeError: If the YAML at ``path`` is not a rocket config
+            (e.g. the GTM-140 drone config was passed by mistake).
+    """
+    config = BaseVehicleConfig.from_yaml(path)
+    if not isinstance(config, RocketConfig):
+        raise TypeError(
+            f"{path} did not load as a RocketConfig (got {type(config).__name__}); "
+            "this generator is for Project B (ramjet_rocket) only"
+        )
+    return config
+
+
+def su2_config_filename(mach: float) -> str:
+    """Return the conventional filename for a Mach case's SU2 config.
 
     Args:
         mach: Freestream Mach number.
-        aoa_deg: Angle of attack in degrees.
 
     Returns:
-        SU2 configuration file contents as a string.
-
-    Note:
-        Stub: farfield pressure/temperature and reference area/length are
-        placeholders and MUST be set from the vehicle config and ISA
-        conditions before use (see module ``TODO``).
+        Filename of the form ``su2_ramjet_mach{M}.cfg``, e.g.
+        ``su2_ramjet_mach2p50.cfg`` for Mach 2.5.
     """
-    lines = [f"% SU2 case  Mach={mach}  AoA={aoa_deg} deg  (MELprop ramP)"]
+    mach_tag = f"{mach:.2f}".replace(".", "p")
+    return f"su2_ramjet_mach{mach_tag}.cfg"
+
+
+def build_su2_config(
+    config: RocketConfig,
+    mach: float,
+    aoa_deg: float = 0.0,
+    altitude_m: float = DESIGN_ALTITUDE_M,
+) -> str:
+    """Render an SU2 Euler ``.cfg`` text for one Mach/AoA case.
+
+    Geometry (reference area/length, body length, fin span/chord) is
+    pulled from ``config`` so the deck stays in sync with the committed
+    vehicle YAML; only the solver numerics in :data:`_BASE_CONFIG` and
+    the freestream state (ISA at ``altitude_m``) are template constants.
+
+    Args:
+        config: Validated two-stage rocket configuration (Project B).
+        mach: Freestream Mach number. Intended for the transonic/
+            supersonic regime (Mach >= 0.6) where AVL is invalid;
+            no upper/lower bound is enforced here so the sweep can be
+            extended, but values are expected to be >= 0.6 in practice.
+        aoa_deg: Angle of attack in degrees.
+        altitude_m: ISA altitude [m] used for freestream pressure and
+            temperature (defaults to the ramjet design altitude used
+            elsewhere in the project, 10,000 m).
+
+    Returns:
+        SU2 configuration file contents as a string, ready to write to
+        disk (not executed by this function).
+
+    Raises:
+        ValueError: If required geometry fields are missing or
+            non-physical (mirrors the guard in ``analyses/aero/
+            avl_builder.py::build_avl_deck``).
+    """
+    if config.body.diameter_m <= 0.0:
+        raise ValueError("body.diameter_m must be > 0")
+    if config.fins.span_m <= 0.0:
+        raise ValueError("fins.span_m must be > 0")
+
+    d_ref_m = config.body.diameter_m
+    a_ref_m2 = math.pi / 4.0 * d_ref_m**2
+    body_length_m = config.body.total_length_m or config.body.length_m
+    fin_span_m = config.fins.span_m
+    fin_chord_root_m = config.fins.chord_root_m or fin_span_m
+    fin_chord_tip_m = config.fins.chord_tip_m or fin_chord_root_m
+    fin_count = config.fins.count
+
+    temperature_K, pressure_Pa, _density_kg_m3 = isa_atmosphere(altitude_m)
+
+    filename = su2_config_filename(mach)
+    restart_stem = filename.rsplit(".", 1)[0]
+
+    lines: list[str] = [
+        f"% MELprop-IADE ramP -- SU2 Euler case, vehicle={config.name!r}",
+        f"% Mach={mach}  AoA={aoa_deg} deg  altitude={altitude_m:.0f} m ISA",
+        "# TO RUN: su2_CFD " + filename,
+        "%",
+        "% --- Geometry (from vehicles/ramjet_rocket/vehicle_config.yaml) ---",
+        f"% body_length_m= {body_length_m:.4f}",
+        f"% body_diameter_m= {d_ref_m:.4f}",
+        f"% fin_count= {fin_count}",
+        f"% fin_span_m= {fin_span_m:.4f}",
+        f"% fin_chord_root_m= {fin_chord_root_m:.4f}",
+        f"% fin_chord_tip_m= {fin_chord_tip_m:.4f}",
+        "%",
+    ]
     lines += [f"{k}= {v}" for k, v in _BASE_CONFIG.items()]
     lines += [
+        "%",
+        "% --- Flight condition ---",
         f"MACH_NUMBER= {mach}",
         f"AOA= {aoa_deg}",
-        "FREESTREAM_PRESSURE= 26500   % TODO: ISA at design altitude [Pa]",
-        "FREESTREAM_TEMPERATURE= 223.3 % TODO: ISA at design altitude [K]",
-        "REF_AREA= 0.04909            % pi/4 * 0.250^2 [m^2]",
-        "REF_LENGTH= 0.250            % d_ref [m]",
-        "MESH_FILENAME= ramp_airframe.su2  % TODO: gmsh output",
+        f"FREESTREAM_TEMPERATURE= {temperature_K:.2f}  % ISA @ {altitude_m:.0f} m [K]",
+        f"FREESTREAM_PRESSURE= {pressure_Pa:.1f}  % ISA @ {altitude_m:.0f} m [Pa]",
+        "%",
+        "% --- Reference quantities (body-diameter based) ---",
+        "REF_ORIGIN_MOMENT_X= "
+        f"{config.mass_properties.cg_from_nose_m if config.mass_properties else 0.0:.4f}",
+        "REF_ORIGIN_MOMENT_Y= 0.0",
+        "REF_ORIGIN_MOMENT_Z= 0.0",
+        f"REF_AREA= {a_ref_m2:.6f}  % pi/4 * d_ref^2 [m^2]",
+        f"REF_LENGTH= {d_ref_m:.4f}  % body diameter d_ref [m]",
+        "%",
+        "% --- Mesh (gmsh output; not produced by this module) ---",
+        "MESH_FILENAME= ramp_airframe.su2  % TODO: gmsh axisymmetric body+fins mesh",
+        "MESH_FORMAT= SU2",
+        f"SOLUTION_FILENAME= restart_{restart_stem}.dat",
+        f"RESTART_FILENAME= restart_{restart_stem}.dat",
+        f"CONV_FILENAME= history_{restart_stem}",
     ]
-    return "\n".join(lines)
+    return "\n".join(lines) + "\n"
 
 
-def build_mach_sweep() -> dict[float, str]:
-    """Build SU2 configs for every Mach in :data:`MACH_SWEEP`.
+def build_mach_sweep(
+    config: RocketConfig | None = None,
+    mach_sweep: tuple[float, ...] = MACH_SWEEP,
+    aoa_deg: float = 0.0,
+    altitude_m: float = DESIGN_ALTITUDE_M,
+) -> dict[float, str]:
+    """Build SU2 configs for every Mach in ``mach_sweep``.
+
+    Args:
+        config: Rocket configuration; loaded from
+            :data:`VEHICLE_CONFIG_PATH` if omitted.
+        mach_sweep: Mach numbers to generate a case for.
+        aoa_deg: Angle of attack in degrees, shared by all cases.
+        altitude_m: ISA altitude [m] for the freestream state.
 
     Returns:
         Mapping of Mach number to its SU2 ``.cfg`` text.
     """
-    return {mach: build_su2_config(mach) for mach in MACH_SWEEP}
+    if config is None:
+        config = load_rocket_config()
+    return {
+        mach: build_su2_config(config, mach, aoa_deg=aoa_deg, altitude_m=altitude_m)
+        for mach in mach_sweep
+    }
+
+
+def write_mach_sweep_configs(
+    config: RocketConfig | None = None,
+    output_dir: Path | str = OUTPUT_DIR,
+    mach_sweep: tuple[float, ...] = MACH_SWEEP,
+    aoa_deg: float = 0.0,
+    altitude_m: float = DESIGN_ALTITUDE_M,
+) -> list[Path]:
+    """Generate and write one SU2 ``.cfg`` file per Mach number to disk.
+
+    This performs file generation ONLY -- it never invokes ``su2_CFD``,
+    ``gmsh``, or any other external binary.
+
+    Args:
+        config: Rocket configuration; loaded from
+            :data:`VEHICLE_CONFIG_PATH` if omitted.
+        output_dir: Directory to write the ``.cfg`` files into (created
+            if missing).
+        mach_sweep: Mach numbers to generate a case for.
+        aoa_deg: Angle of attack in degrees, shared by all cases.
+        altitude_m: ISA altitude [m] for the freestream state.
+
+    Returns:
+        List of paths written, one per entry in ``mach_sweep``, in the
+        same order.
+    """
+    if config is None:
+        config = load_rocket_config()
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    written: list[Path] = []
+    for mach in mach_sweep:
+        text = build_su2_config(config, mach, aoa_deg=aoa_deg, altitude_m=altitude_m)
+        path = output_dir / su2_config_filename(mach)
+        path.write_text(text, encoding="utf-8")
+        written.append(path)
+    return written
+
+
+class SU2ConfigGeneration(BaseAnalysis):
+    """Generates SU2 Euler ``.cfg`` files for the ramjet Mach sweep.
+
+    This is a Level-2 (Euler CFD) *preprocessing* analysis: it writes
+    solver-ready configuration text but never runs SU2 itself (not
+    installed in this environment). ``execute()`` returns the count and
+    paths of the configs written so downstream workflows can locate them
+    once a container with SU2 is used to actually run the cases.
+
+    Example:
+        >>> analysis = SU2ConfigGeneration()
+        >>> analysis.setup(rocket_config)
+        >>> results = analysis.execute()
+        >>> results["n_configs"]  # doctest: +SKIP
+    """
+
+    fidelity = FidelityLevel.LEVEL_2
+
+    def __init__(self, name: str = "su2_euler_mach_sweep") -> None:
+        super().__init__(name)
+        self._config: RocketConfig | None = None
+        self._mach_sweep: tuple[float, ...] = MACH_SWEEP
+        self._aoa_deg = 0.0
+        self._altitude_m = DESIGN_ALTITUDE_M
+        self._output_dir = OUTPUT_DIR
+
+    def setup(
+        self,
+        vehicle_config: RocketConfig,
+        mach_sweep: tuple[float, ...] = MACH_SWEEP,
+        aoa_deg: float = 0.0,
+        altitude_m: float = DESIGN_ALTITUDE_M,
+        output_dir: Path | str = OUTPUT_DIR,
+    ) -> None:
+        """Bind the analysis to a rocket config and Mach sweep.
+
+        Args:
+            vehicle_config: Validated rocket configuration with body/fins.
+            mach_sweep: Mach numbers to generate a case for.
+            aoa_deg: Angle of attack in degrees, shared by all cases.
+            altitude_m: ISA altitude [m] for the freestream state.
+            output_dir: Directory the ``.cfg`` files are written into.
+
+        Raises:
+            ValueError: If the config has no body/fins definition.
+        """
+        if getattr(vehicle_config, "body", None) is None:
+            raise ValueError("vehicle_config must define body")
+        if getattr(vehicle_config, "fins", None) is None:
+            raise ValueError("vehicle_config must define fins")
+        self._config = vehicle_config
+        self._mach_sweep = mach_sweep
+        self._aoa_deg = aoa_deg
+        self._altitude_m = altitude_m
+        self._output_dir = Path(output_dir)
+        self._is_setup = True
+
+    def execute(self) -> AnalysisResults:
+        """Write one SU2 config per Mach number and report the paths.
+
+        Returns:
+            AnalysisResults with ``n_configs`` (float count) in ``data``
+            and the written file paths / Mach sweep in ``metadata``.
+
+        Raises:
+            RuntimeError: If called before :meth:`setup`.
+        """
+        if not self._is_setup or self._config is None:
+            raise RuntimeError("SU2ConfigGeneration.execute() called before setup()")
+
+        paths = write_mach_sweep_configs(
+            self._config,
+            output_dir=self._output_dir,
+            mach_sweep=self._mach_sweep,
+            aoa_deg=self._aoa_deg,
+            altitude_m=self._altitude_m,
+        )
+
+        return AnalysisResults(
+            name=self.name,
+            fidelity=self.fidelity,
+            data={"n_configs": float(len(paths))},
+            metadata={
+                "method": "su2_config_file_generation_only",
+                "mach_sweep": self._mach_sweep,
+                "aoa_deg": self._aoa_deg,
+                "altitude_m": self._altitude_m,
+                "config_paths": [str(p) for p in paths],
+                "note": (
+                    "SU2 binary was NOT invoked (not installed in this "
+                    "environment); run manually with the `# TO RUN:` "
+                    "comment in each generated file once available"
+                ),
+            },
+        )
+
+    def validate_results(self, results: AnalysisResults) -> bool:
+        """Check one config file was written per Mach in the sweep."""
+        return results["n_configs"] == float(len(self._mach_sweep))
+
+
+def run(config_path: Path | str = VEHICLE_CONFIG_PATH) -> list[Path]:
+    """Generate the full Mach-sweep SU2 config set and print a summary.
+
+    Args:
+        config_path: Path to the ramjet-rocket ``vehicle_config.yaml``.
+
+    Returns:
+        List of written ``.cfg`` file paths.
+    """
+    config = load_rocket_config(config_path)
+    analysis = SU2ConfigGeneration()
+    analysis.setup(config)
+    results = analysis.execute()
+    return [Path(p) for p in results.metadata["config_paths"]]
+
+
+if __name__ == "__main__":
+    paths = run()
+    print(f"Wrote {len(paths)} SU2 Euler configs to {OUTPUT_DIR}:")
+    for p in paths:
+        print(f"  {p}")

--- a/analyses/propulsion/combustor_nozzle_cycle.py
+++ b/analyses/propulsion/combustor_nozzle_cycle.py
@@ -1,0 +1,834 @@
+# MELprop-IADE | analyses.propulsion.combustor_nozzle_cycle | v0.1.0
+"""Grzywka-station combustor + nozzle cycle model (stations 1-2-21-3).
+
+Complementary — NOT a replacement — to
+:mod:`analyses.propulsion.ramjet_cycle`. Where ``ramjet_cycle`` uses the
+classical Mattingly ramjet station numbering (0-2-4-9) with a burner
+total-pressure ratio ``pi_b`` and dual (matched / cylindrical) nozzle
+reporting, this module reproduces the station numbering, loss
+coefficients and three-thrust-model reporting of Grzywka's ramjet
+combustor/nozzle analysis (Grzywka, *Analiza numeryczna komory spalania
+i dyszy silnika strumieniowego*, dyplom/praca, Politechnika Warszawska,
+2022 — the project's primary combustor/nozzle reference, cited here the
+same way ``ramjet_cycle`` cites Mattingly / Hill & Peterson).
+
+Grzywka station numbering used throughout:
+
+    1  -> combustor inlet (post-diffuser; the inlet total-pressure
+          recovery ``eta_inlet`` is ALREADY applied here, so this is the
+          same physical plane as ``ramjet_cycle`` station 2). Adiabatic
+          up to this point: ``Tt1 = Tt0``.
+    2  -> combustor exit (post heat-addition to ``combustor_exit_temp_K``,
+          with the combustion-chamber total-pressure ratio ``pi_CC``:
+          ``pt2 = pi_CC * pt1``).
+    21 -> nozzle throat. **Choked, ``Ma_21 = 1`` ALWAYS**, with a
+          **DYNAMIC** cross-sectional area ``A21`` solved from continuity
+          (``mdot = rho*A*u`` at sonic conditions) for the current cycle
+          mass flow and station-2 total conditions. ``A21`` is therefore
+          a function of flight speed ``V`` and altitude ``H`` and is NEVER
+          hard-coded to a fixed diameter.
+    3  -> nozzle exit. Isentropic expansion of the hot gas to ambient
+          static pressure ``p0`` (fully expanded), with the nozzle-duct
+          total-pressure loss ``pi_nozzle`` applied on top of the
+          isentropic expansion (``pt3_eff = pi_nozzle * pt2``).
+
+Three thrust models (Grzywka Sec. 6.2.2), the standard
+ideal / combustor-loss / real hierarchy — ALL THREE ARE ALWAYS
+REPORTED, never collapsed to a single number:
+
+    Thi -- IDEAL thrust. No combustor or nozzle total-pressure losses
+           (``pi_CC = 1``, ``pi_nozzle = 1``); fully-expanded isentropic
+           1-D reference. Upper bound.
+    Th1 -- thrust with the COMBUSTOR total-pressure loss ``pi_CC``
+           included, but the nozzle still idealized (``pi_nozzle = 1``,
+           fully expanded).
+    Th2 -- REAL thrust with BOTH ``pi_CC`` and ``pi_nozzle`` losses
+           included. Most conservative; this is the field consumed as
+           the nominal by later cruise-wiring work (Phase 3b).
+
+The three share identical mass flow, ``Tt1``, ``Tt2`` and fuel-air ratio
+(only the delivered nozzle total pressure differs), so the physical
+hierarchy ``Thi >= Th1 >= Th2`` MUST hold and is asserted both in
+:meth:`GrzywkaCombustorNozzleAnalysis.validate_results` and in the unit
+tests.
+
+Fidelity: this is a 1-D station cycle (closed-form compressible-flow
+relations with a continuity-solved sonic throat) — the same rung as
+``ramjet_cycle``. It is kept at ``FidelityLevel.LEVEL_2`` deliberately:
+the extra throat station (21) is finer station granularity, NOT a
+higher-fidelity method class (LEVEL_3 is reserved for RANS CFD / FEM per
+:class:`core.component_base.FidelityLevel`).
+
+Cross-checks surfaced (not hidden) in metadata, matching this repo's
+convention of quantifying method discrepancies:
+    * Brayton T2 cross-check -- an independently-coded, single-gas
+      (cold-cp) Brayton heat-addition estimate of the station-2 total
+      temperature, compared with the station model's ``Tt2``. Flagged
+      (logged, NOT failed) if the delta exceeds 5%.
+    * V3 vs Teltik 2024 CFD (~1047 m/s at Mach 2.5 / 6000 m, docs/
+      assumptions.md A15) -- logged as a delta, agreement NOT forced.
+    * Implied nozzle area ratio A3/A21 vs vehicle_config.yaml
+      ``nozzle_area_ratio`` = 4.0 (design intent) AND the Fusion v6 CAD
+      cylindrical stub (``expansion_ratio`` = 1.0) -- both logged, the
+      CAD-vs-design gap quantified rather than silently resolved.
+
+References:
+    Grzywka, *Analiza numeryczna komory spalania i dyszy silnika
+    strumieniowego*, Politechnika Warszawska, 2022 -- station numbering
+    (1-2-21-3), loss coefficients ``pi_CC`` / ``pi_nozzle``, and the
+    Thi / Th1 / Th2 three-thrust decomposition (Sec. 6.2.2).
+    Mattingly, J. D., *Elements of Gas Turbine Propulsion*, 2nd ed.,
+    AIAA, 2006 -- Ch. 3, 9 (ramjet cycle, choked-nozzle relations).
+    Hill, P. G. & Peterson, C. R., *Mechanics and Thermodynamics of
+    Propulsion*, 2nd ed., Addison-Wesley, 1992 -- Ch. 5, 11.
+    Anderson, J. D., *Modern Compressible Flow*, 3rd ed., McGraw-Hill,
+    2003 -- Ch. 3 (isentropic / choked / stagnation relations).
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import sys
+from pathlib import Path
+from typing import Any
+
+if __package__ in (None, ""):
+    # Allow `python3 analyses/propulsion/combustor_nozzle_cycle.py` direct
+    # execution by putting the repository root (three levels up) on
+    # sys.path so the `core` package resolves, mirroring conftest.py.
+    sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from analyses.propulsion.inlet_performance import (
+    CAPTURE_AREA_M2,
+    DEFAULT_N_CONES_M25,
+    DESIGN_ALTITUDE_M,
+    G0,
+    GAMMA as GAMMA_COLD,
+    MACH_DESIGN,
+    MultiConeInletPerformanceAnalysis,
+    isa_atmosphere,
+)
+from analyses.propulsion.ramjet_cycle import (
+    CP_COLD,
+    CP_HOT,
+    ETA_B_DEFAULT,
+    GAMMA_HOT,
+    KEROSENE_H_PR,
+    NOZZLE_AREA_RATIO_CYLINDRICAL,
+    NOZZLE_AREA_RATIO_DESIGN,
+    R_HOT,
+    TT4_DEFAULT_K,
+    stagnation_pressure_Pa,
+    stagnation_temperature_K,
+)
+from core.component_base import AnalysisResults, BaseAnalysis, FidelityLevel
+
+# --------------------------------------------------------------------------
+# Grzywka 2022 loss coefficients (SI / dimensionless)
+# --------------------------------------------------------------------------
+
+#: Combustion-chamber total-pressure ratio pt2/pt1 (station 1->2),
+#: Grzywka 2022 (docs/assumptions.md A13).
+PI_CC: float = 0.8924
+
+#: Nozzle total-pressure ratio pt3/pt2 (station 2->3), the nozzle-duct
+#: loss applied on top of the isentropic expansion, Grzywka 2022
+#: (docs/assumptions.md A13).
+PI_NOZZLE: float = 0.97
+
+#: Combustor-exit total temperature Tt2 [K] -- placeholder from
+#: vehicles/ramjet_rocket/vehicle_config.yaml stage_2.combustor_temp_K
+#: (TBD; deliberately BELOW the ~2400 K flame-holder risk figure, see the
+#: combustor risk baseline shared with ramjet_cycle / assumptions A4).
+COMBUSTOR_EXIT_TEMP_DEFAULT_K: float = TT4_DEFAULT_K
+
+#: Material total-temperature ceiling used as a sanity bound on the
+#: combustor exit temperature [K]. TODO_PHYSICAL_PARAM: the ~2400 K
+#: flame-holder cavity figure (assumptions A4) is the governing risk
+#: number; 2500 K here is a loose upper sanity bound, not a cleared
+#: material limit.
+COMBUSTOR_TEMP_CEILING_K: float = 2500.0
+
+# --------------------------------------------------------------------------
+# Teltik 2024 CFD reference point (docs/assumptions.md A15)
+# --------------------------------------------------------------------------
+
+#: Teltik 2024 CFD nozzle-exit velocity [m/s] at the reference condition.
+TELTIK_V3_M_S: float = 1047.0
+
+#: Teltik 2024 CFD reference Mach number.
+TELTIK_MACH: float = 2.5
+
+#: Teltik 2024 CFD reference altitude [m].
+TELTIK_ALTITUDE_M: float = 6000.0
+
+
+def choked_throat_area_m2(
+    mdot_kg_s: float,
+    tt2_K: float,
+    pt2_Pa: float,
+    gamma_t: float,
+    r_t: float,
+) -> dict[str, float]:
+    """Solve the sonic (choked, Ma=1) nozzle-throat area from continuity.
+
+    The throat (Grzywka station 21) is choked at ALL flight conditions.
+    Its area is therefore not a fixed geometric constant but the area
+    required to pass the current cycle mass flow at sonic conditions for
+    the given station-2 total state (``mdot = rho*A*u`` with ``u = a``,
+    ``Ma = 1``; Anderson, *Modern Compressible Flow*, 3rd ed., Ch. 3
+    critical/choked relations):
+
+        T21 = Tt2 * 2/(gamma+1)
+        p21 = pt2 * (2/(gamma+1))^(gamma/(gamma-1))
+        a21 = sqrt(gamma*R*T21)             (= u21, since Ma21 = 1)
+        rho21 = p21/(R*T21)
+        A21 = mdot / (rho21 * a21)
+
+    Args:
+        mdot_kg_s: Nozzle mass flow (combustor exit, air + fuel) [kg/s].
+        tt2_K: Combustor-exit (station 2) total temperature [K].
+        pt2_Pa: Combustor-exit (station 2) total pressure [Pa].
+        gamma_t: Hot-gas ratio of specific heats.
+        r_t: Hot-gas specific gas constant [J/(kg*K)].
+
+    Returns:
+        Dict with ``A21_m2``, ``D21_m`` (equivalent circular diameter),
+        ``T21_K``, ``p21_Pa``, ``u21_m_s`` (= sonic speed), ``rho21_kg_m3``
+        and ``Ma21`` (== 1.0).
+    """
+    critical_ratio = 2.0 / (gamma_t + 1.0)
+    t21_K = tt2_K * critical_ratio
+    p21_Pa = pt2_Pa * critical_ratio ** (gamma_t / (gamma_t - 1.0))
+    a21_m_s = math.sqrt(gamma_t * r_t * t21_K)
+    rho21_kg_m3 = p21_Pa / (r_t * t21_K)
+    a21_area_m2 = mdot_kg_s / (rho21_kg_m3 * a21_m_s)
+    d21_m = math.sqrt(4.0 * a21_area_m2 / math.pi)
+    return {
+        "A21_m2": a21_area_m2,
+        "D21_m": d21_m,
+        "T21_K": t21_K,
+        "p21_Pa": p21_Pa,
+        "u21_m_s": a21_m_s,
+        "rho21_kg_m3": rho21_kg_m3,
+        "Ma21": 1.0,
+    }
+
+
+def fully_expanded_exit(
+    tt2_K: float,
+    pt_nozzle_Pa: float,
+    p0_Pa: float,
+    mdot_kg_s: float,
+    gamma_t: float,
+    cp_t: float,
+    r_t: float,
+) -> dict[str, float]:
+    """Isentropically expand the hot gas to ambient static pressure.
+
+    Fully-expanded (``p3 = p0``) nozzle exit (Grzywka station 3). The
+    delivered nozzle total pressure ``pt_nozzle_Pa`` is what encodes the
+    loss level of a given thrust model (``pt1``, ``pi_CC*pt1`` or
+    ``pi_nozzle*pi_CC*pt1``); a lower total pressure yields a higher exit
+    static temperature and thus a lower exit velocity (Anderson Ch. 3
+    isentropic relations; Mattingly Ch. 9):
+
+        T3 = Tt2 * (p0/pt_nozzle)^((gamma-1)/gamma)
+        V3 = sqrt(2*cp*(Tt2 - T3))
+
+    Args:
+        tt2_K: Combustor-exit total temperature [K].
+        pt_nozzle_Pa: Total pressure delivered to the nozzle [Pa].
+        p0_Pa: Ambient (freestream) static pressure [Pa].
+        mdot_kg_s: Nozzle mass flow [kg/s].
+        gamma_t: Hot-gas ratio of specific heats.
+        cp_t: Hot-gas specific heat at constant pressure [J/(kg*K)].
+        r_t: Hot-gas specific gas constant [J/(kg*K)].
+
+    Returns:
+        Dict with ``T3_K``, ``p3_Pa`` (== p0_Pa), ``V3_m_s``,
+        ``rho3_kg_m3``, ``A3_m2`` and ``Ma3``.
+    """
+    t3_K = tt2_K * (p0_Pa / pt_nozzle_Pa) ** ((gamma_t - 1.0) / gamma_t)
+    v3_m_s = math.sqrt(2.0 * cp_t * (tt2_K - t3_K))
+    rho3_kg_m3 = p0_Pa / (r_t * t3_K)
+    a3_area_m2 = mdot_kg_s / (rho3_kg_m3 * v3_m_s)
+    a3_speed_m_s = math.sqrt(gamma_t * r_t * t3_K)
+    return {
+        "T3_K": t3_K,
+        "p3_Pa": p0_Pa,
+        "V3_m_s": v3_m_s,
+        "rho3_kg_m3": rho3_kg_m3,
+        "A3_m2": a3_area_m2,
+        "Ma3": v3_m_s / a3_speed_m_s,
+    }
+
+
+def brayton_t2_estimate_K(
+    tt1_K: float,
+    f_fuel_air: float,
+    eta_b: float,
+    h_PR: float,
+    cp_cold: float,
+) -> float:
+    """Independent single-gas Brayton estimate of the combustor-exit Tt2.
+
+    Deliberately a SEPARATE code path from the station model (it does not
+    call :func:`choked_throat_area_m2` / :func:`fully_expanded_exit`): a
+    constant-``cp`` Brayton heat-addition to the COLD-gas specific heat
+    (Hill & Peterson Ch. 5 ideal-cycle heat addition):
+
+        Tt2_brayton = Tt1 + f*eta_b*h_PR / (cp_cold*(1 + f))
+
+    The station model instead uses the HOT-gas ``cp_t`` and a different
+    algebraic sink term, so the two are expected to disagree; the delta
+    is surfaced in metadata (flagged if > 5%) rather than forced to
+    match, per this repo's method-discrepancy convention.
+
+    Args:
+        tt1_K: Combustor-inlet total temperature [K].
+        f_fuel_air: Fuel-air ratio [-].
+        eta_b: Combustion efficiency [-].
+        h_PR: Fuel lower heating value [J/kg].
+        cp_cold: Cold-gas specific heat at constant pressure [J/(kg*K)].
+
+    Returns:
+        Brayton-estimated combustor-exit total temperature [K].
+    """
+    return tt1_K + f_fuel_air * eta_b * h_PR / (cp_cold * (1.0 + f_fuel_air))
+
+
+class GrzywkaCombustorNozzleAnalysis(BaseAnalysis):
+    """Grzywka-station combustor+nozzle cycle (stations 1-2-21-3).
+
+    Reports the three-thrust decomposition (``Thi`` / ``Th1`` / ``Th2``)
+    with a dynamically-solved choked throat area ``A21`` (see the module
+    docstring). 1-D station cycle -> ``FidelityLevel.LEVEL_2`` (the extra
+    throat station is finer granularity, not a higher method class; see
+    the module docstring for the LEVEL_2-vs-LEVEL_3 justification).
+
+    Example:
+        >>> analysis = GrzywkaCombustorNozzleAnalysis()
+        >>> analysis.setup(mach0=2.5, altitude_m=10_000.0)
+        >>> results = analysis.execute()
+        >>> results["Thi_N"] >= results["Th1_N"] >= results["Th2_N"]  # doctest: +SKIP
+    """
+
+    fidelity = FidelityLevel.LEVEL_2
+
+    def __init__(self, name: str = "grzywka_combustor_nozzle_cycle") -> None:
+        super().__init__(name)
+        self._mach0 = MACH_DESIGN
+        self._altitude_m = DESIGN_ALTITUDE_M
+        self._tt2_K = COMBUSTOR_EXIT_TEMP_DEFAULT_K
+        self._eta_inlet: float | None = None
+        self._pi_cc = PI_CC
+        self._pi_nozzle = PI_NOZZLE
+        self._eta_b = ETA_B_DEFAULT
+        self._h_PR = KEROSENE_H_PR
+        self._gamma_t = GAMMA_HOT
+        self._cp_t = CP_HOT
+        self._r_t = R_HOT
+        self._cp_cold = CP_COLD
+        self._gamma_cold = GAMMA_COLD
+        self._capture_area_m2 = CAPTURE_AREA_M2
+
+    def setup(
+        self,
+        mach0: float = MACH_DESIGN,
+        altitude_m: float = DESIGN_ALTITUDE_M,
+        combustor_exit_temp_K: float = COMBUSTOR_EXIT_TEMP_DEFAULT_K,
+        eta_inlet: float | None = None,
+        pi_cc: float = PI_CC,
+        pi_nozzle: float = PI_NOZZLE,
+        eta_b: float = ETA_B_DEFAULT,
+        h_PR: float = KEROSENE_H_PR,
+        gamma_t: float = GAMMA_HOT,
+        cp_t: float = CP_HOT,
+        cp_cold: float = CP_COLD,
+        capture_area_m2: float = CAPTURE_AREA_M2,
+    ) -> None:
+        """Bind the analysis to a design point and Grzywka loss set.
+
+        Args:
+            mach0: Freestream Mach number (must be > 1).
+            altitude_m: ISA altitude [m].
+            combustor_exit_temp_K: Station-2 total temperature Tt2 [K]
+                (placeholder default 2000 -- see the combustor risk
+                baseline in ramjet_cycle / assumptions A4).
+            eta_inlet: Inlet total-pressure recovery override. If ``None``
+                (default), computed from the 4-cone preset chain of
+                :class:`MultiConeInletPerformanceAnalysis` at (``mach0``,
+                ``altitude_m``), exactly as ``ramjet_cycle`` does.
+            pi_cc: Combustion-chamber total-pressure ratio pt2/pt1
+                (Grzywka, default 0.8924).
+            pi_nozzle: Nozzle-duct total-pressure ratio pt3/pt2 (Grzywka,
+                default 0.97).
+            eta_b: Combustion efficiency (placeholder, default 0.95 --
+                shared with ramjet_cycle).
+            h_PR: Fuel lower heating value [J/kg] (default kerosene).
+            gamma_t: Hot-gas ratio of specific heats.
+            cp_t: Hot-gas specific heat at constant pressure [J/(kg*K)].
+            cp_cold: Cold-gas specific heat (for the Brayton cross-check).
+            capture_area_m2: Inlet capture area [m^2] (full-capture
+                assumption, as in inlet_performance / ramjet_cycle).
+
+        Raises:
+            ValueError: If mach0 <= 1; pi_cc, pi_nozzle, eta_b or (when
+                given) eta_inlet outside (0, 1]; or combustor_exit_temp_K
+                does not exceed the recovered combustor-inlet total
+                temperature Tt1 (= Tt0).
+        """
+        if mach0 <= 1.0:
+            raise ValueError(f"mach0 must be > 1, got {mach0}")
+        for label, value in (
+            ("pi_cc", pi_cc),
+            ("pi_nozzle", pi_nozzle),
+            ("eta_b", eta_b),
+        ):
+            if not (0.0 < value <= 1.0):
+                raise ValueError(f"{label} must be in (0, 1], got {value}")
+        if eta_inlet is not None and not (0.0 < eta_inlet <= 1.0):
+            raise ValueError(f"eta_inlet must be in (0, 1], got {eta_inlet}")
+
+        atmosphere = isa_atmosphere(altitude_m)
+        tt1_preview_K = stagnation_temperature_K(
+            atmosphere.temperature_K, mach0, self._gamma_cold
+        )
+        if combustor_exit_temp_K <= tt1_preview_K:
+            raise ValueError(
+                f"combustor_exit_temp_K ({combustor_exit_temp_K}) must exceed "
+                f"the combustor-inlet total temperature Tt1=Tt0 "
+                f"({tt1_preview_K:.2f} K) at mach0={mach0}, altitude_m={altitude_m}"
+            )
+
+        self._mach0 = mach0
+        self._altitude_m = altitude_m
+        self._tt2_K = combustor_exit_temp_K
+        self._eta_inlet = eta_inlet
+        self._pi_cc = pi_cc
+        self._pi_nozzle = pi_nozzle
+        self._eta_b = eta_b
+        self._h_PR = h_PR
+        self._gamma_t = gamma_t
+        self._cp_t = cp_t
+        self._r_t = cp_t * (gamma_t - 1.0) / gamma_t
+        self._cp_cold = cp_cold
+        self._capture_area_m2 = capture_area_m2
+        self._is_setup = True
+
+    def _resolve_eta_inlet(
+        self, mach0: float, altitude_m: float
+    ) -> tuple[float, str]:
+        """Resolve the inlet recovery, computing it if not overridden.
+
+        Args:
+            mach0: Freestream Mach number.
+            altitude_m: ISA altitude [m].
+
+        Returns:
+            Tuple ``(eta_inlet, source)``; ``source`` records whether the
+            value was a caller override or the 4-cone preset chain.
+        """
+        if self._eta_inlet is not None:
+            return self._eta_inlet, "user_override"
+
+        inlet_analysis = MultiConeInletPerformanceAnalysis()
+        inlet_analysis.setup(
+            mach_design=mach0,
+            altitude_m=altitude_m,
+            n_cones=DEFAULT_N_CONES_M25,
+            optimize_angles=False,
+        )
+        return inlet_analysis.execute()["eta_inlet"], "multi_cone_4preset_chain"
+
+    def _run_condition(self, mach0: float, altitude_m: float) -> dict[str, Any]:
+        """Evaluate the full 1-2-21-3 cycle at a single (V, H) condition.
+
+        Factored out so the design point and the Teltik-CFD comparison
+        point (Mach 2.5 / 6000 m) share exactly the same station math.
+
+        Args:
+            mach0: Freestream Mach number.
+            altitude_m: ISA altitude [m].
+
+        Returns:
+            Dict with the three thrust models, throat solution, exit
+            solutions, mass flows and fuel-air ratio for this condition.
+        """
+        eta_inlet, eta_inlet_source = self._resolve_eta_inlet(mach0, altitude_m)
+
+        atmosphere = isa_atmosphere(altitude_m)
+        p0_Pa = atmosphere.pressure_Pa
+        a0_m_s = atmosphere.speed_of_sound_m_s
+        u0_m_s = mach0 * a0_m_s
+
+        tt1_K = stagnation_temperature_K(atmosphere.temperature_K, mach0, self._gamma_cold)
+        pt0_Pa = stagnation_pressure_Pa(p0_Pa, mach0, self._gamma_cold)
+        pt1_Pa = eta_inlet * pt0_Pa
+
+        # Fuel-air ratio from the steady-flow energy balance (hot gas),
+        # shared definition with ramjet_cycle (Mattingly Eq. 2.15 /
+        # Hill & Peterson Eq. 11.19). Common to all three thrust models.
+        f_fuel_air = (
+            self._cp_t
+            * (self._tt2_K - tt1_K)
+            / (self._eta_b * self._h_PR - self._cp_t * self._tt2_K)
+        )
+
+        mdot_air_kg_s = atmosphere.density_kg_m3 * u0_m_s * self._capture_area_m2
+        mdot_fuel_kg_s = f_fuel_air * mdot_air_kg_s
+        mdot_exit_kg_s = mdot_air_kg_s * (1.0 + f_fuel_air)
+
+        # Combustor exit total pressure (real, with the pi_CC loss).
+        pt2_real_Pa = self._pi_cc * pt1_Pa
+
+        # Dynamic choked throat (station 21) from the REAL combustor-exit
+        # total state -- the physical engine throat.
+        throat = choked_throat_area_m2(
+            mdot_exit_kg_s, self._tt2_K, pt2_real_Pa, self._gamma_t, self._r_t
+        )
+
+        # Three thrust models differ ONLY in the nozzle total pressure.
+        def _thrust(pt_nozzle_Pa: float) -> dict[str, float]:
+            exit_state = fully_expanded_exit(
+                self._tt2_K,
+                pt_nozzle_Pa,
+                p0_Pa,
+                mdot_exit_kg_s,
+                self._gamma_t,
+                self._cp_t,
+                self._r_t,
+            )
+            thrust_N = mdot_exit_kg_s * exit_state["V3_m_s"] - mdot_air_kg_s * u0_m_s
+            return {**exit_state, "thrust_N": thrust_N}
+
+        thi = _thrust(pt1_Pa)  # pi_CC = 1, pi_nozzle = 1
+        th1 = _thrust(self._pi_cc * pt1_Pa)  # pi_CC only
+        th2 = _thrust(self._pi_nozzle * self._pi_cc * pt1_Pa)  # both losses
+
+        brayton_t2_K = brayton_t2_estimate_K(
+            tt1_K, f_fuel_air, self._eta_b, self._h_PR, self._cp_cold
+        )
+
+        return {
+            "mach0": mach0,
+            "altitude_m": altitude_m,
+            "eta_inlet": eta_inlet,
+            "eta_inlet_source": eta_inlet_source,
+            "p0_Pa": p0_Pa,
+            "u0_m_s": u0_m_s,
+            "tt1_K": tt1_K,
+            "pt1_Pa": pt1_Pa,
+            "tt2_K": self._tt2_K,
+            "pt2_real_Pa": pt2_real_Pa,
+            "f_fuel_air": f_fuel_air,
+            "mdot_air_kg_s": mdot_air_kg_s,
+            "mdot_fuel_kg_s": mdot_fuel_kg_s,
+            "mdot_exit_kg_s": mdot_exit_kg_s,
+            "throat": throat,
+            "Thi": thi,
+            "Th1": th1,
+            "Th2": th2,
+            "brayton_t2_K": brayton_t2_K,
+        }
+
+    def execute(self) -> AnalysisResults:
+        """Run the design-point cycle and return results.
+
+        Returns:
+            AnalysisResults with the three thrust models, dynamic choked
+            throat, exit states, the Brayton T2 / Teltik V3 / nozzle
+            area-ratio cross-checks and the full station table.
+
+        Raises:
+            RuntimeError: If called before :meth:`setup`, or if the
+                results fail :meth:`validate_results`.
+        """
+        if not self._is_setup:
+            raise RuntimeError(
+                "GrzywkaCombustorNozzleAnalysis.execute() called before setup()"
+            )
+
+        cycle = self._run_condition(self._mach0, self._altitude_m)
+
+        thi_N = cycle["Thi"]["thrust_N"]
+        th1_N = cycle["Th1"]["thrust_N"]
+        th2_N = cycle["Th2"]["thrust_N"]
+
+        # Isp from the REAL (Th2) thrust and the fuel flow.
+        isp_real_s = th2_N / (cycle["mdot_fuel_kg_s"] * G0)
+
+        # Brayton T2 cross-check (independent code path).
+        brayton_t2_K = cycle["brayton_t2_K"]
+        brayton_delta_frac = (brayton_t2_K - cycle["tt2_K"]) / cycle["tt2_K"]
+        brayton_flag = abs(brayton_delta_frac) > 0.05
+
+        # V3 (real, Th2) vs Teltik 2024 CFD at ITS reference condition
+        # (Mach 2.5 / 6000 m), not the design point.
+        teltik_cycle = self._run_condition(TELTIK_MACH, TELTIK_ALTITUDE_M)
+        v3_teltik_model_m_s = teltik_cycle["Th2"]["V3_m_s"]
+        v3_teltik_delta_frac = (v3_teltik_model_m_s - TELTIK_V3_M_S) / TELTIK_V3_M_S
+
+        # Implied nozzle area ratio A3(real)/A21 at the design point.
+        area_ratio_model = cycle["Th2"]["A3_m2"] / cycle["throat"]["A21_m2"]
+
+        station_table = [
+            {
+                "station": "1_combustor_inlet",
+                "total_temperature_K": cycle["tt1_K"],
+                "total_pressure_Pa": cycle["pt1_Pa"],
+            },
+            {
+                "station": "2_combustor_exit",
+                "total_temperature_K": cycle["tt2_K"],
+                "total_pressure_Pa": cycle["pt2_real_Pa"],
+            },
+            {
+                "station": "21_nozzle_throat_choked",
+                "mach": cycle["throat"]["Ma21"],
+                "static_temperature_K": cycle["throat"]["T21_K"],
+                "static_pressure_Pa": cycle["throat"]["p21_Pa"],
+                "velocity_m_s": cycle["throat"]["u21_m_s"],
+                "area_m2": cycle["throat"]["A21_m2"],
+                "diameter_m": cycle["throat"]["D21_m"],
+            },
+            {
+                "station": "3_nozzle_exit_real_Th2",
+                "mach": cycle["Th2"]["Ma3"],
+                "static_temperature_K": cycle["Th2"]["T3_K"],
+                "static_pressure_Pa": cycle["Th2"]["p3_Pa"],
+                "velocity_m_s": cycle["Th2"]["V3_m_s"],
+                "area_m2": cycle["Th2"]["A3_m2"],
+            },
+        ]
+
+        data: dict[str, Any] = {
+            "Thi_N": thi_N,
+            "Th1_N": th1_N,
+            "Th2_N": th2_N,
+            "thrust_nominal_N": th2_N,
+            "V3i_m_s": cycle["Thi"]["V3_m_s"],
+            "V3_1_m_s": cycle["Th1"]["V3_m_s"],
+            "V3_2_m_s": cycle["Th2"]["V3_m_s"],
+            "V3_m_s": cycle["Th2"]["V3_m_s"],
+            "A21_throat_m2": cycle["throat"]["A21_m2"],
+            "D21_throat_m": cycle["throat"]["D21_m"],
+            "A3_exit_m2": cycle["Th2"]["A3_m2"],
+            "Ma21": cycle["throat"]["Ma21"],
+            "Ma3": cycle["Th2"]["Ma3"],
+            "f_fuel_air": cycle["f_fuel_air"],
+            "isp_s": isp_real_s,
+            "mdot_air_kg_s": cycle["mdot_air_kg_s"],
+            "mdot_fuel_kg_s": cycle["mdot_fuel_kg_s"],
+            "mdot_exit_kg_s": cycle["mdot_exit_kg_s"],
+            "tt1_K": cycle["tt1_K"],
+            "tt2_K": cycle["tt2_K"],
+            "pt1_Pa": cycle["pt1_Pa"],
+            "pt2_Pa": cycle["pt2_real_Pa"],
+            "eta_inlet": cycle["eta_inlet"],
+            "pi_cc": self._pi_cc,
+            "pi_nozzle": self._pi_nozzle,
+            "eta_b": self._eta_b,
+            "mach0": self._mach0,
+            "altitude_m": self._altitude_m,
+            "nozzle_area_ratio_model": area_ratio_model,
+            "nozzle_area_ratio_design_yaml": NOZZLE_AREA_RATIO_DESIGN,
+            "nozzle_area_ratio_cad_cylindrical": NOZZLE_AREA_RATIO_CYLINDRICAL,
+        }
+
+        metadata: dict[str, Any] = {
+            "eta_inlet_source": cycle["eta_inlet_source"],
+            "station_table": station_table,
+            "thrust_model_hierarchy": {
+                "Thi_N": thi_N,
+                "Th1_N": th1_N,
+                "Th2_N": th2_N,
+                "note": (
+                    "Grzywka Sec. 6.2.2 three-thrust decomposition. "
+                    "Thi: ideal, no losses (pi_CC=pi_nozzle=1), fully "
+                    "expanded. Th1: combustor loss pi_CC only. Th2: real, "
+                    "both pi_CC and pi_nozzle (nominal for downstream "
+                    "cruise wiring). Hierarchy Thi>=Th1>=Th2 holds by "
+                    "construction (same mdot/Tt1/Tt2/f; only the delivered "
+                    "nozzle total pressure differs)."
+                ),
+            },
+            "brayton_t2_cross_check": {
+                "station_model_tt2_K": cycle["tt2_K"],
+                "brayton_estimate_tt2_K": brayton_t2_K,
+                "delta_frac": brayton_delta_frac,
+                "exceeds_5pct": brayton_flag,
+                "note": (
+                    "Independently-coded single-gas (cold-cp) Brayton "
+                    "heat-addition estimate of Tt2 vs the station model's "
+                    "Tt2. Delta driven mainly by cold-cp vs hot-cp choice. "
+                    "Logged as an OPEN ITEM if >5%; NOT a validation "
+                    "failure (repo method-discrepancy convention)."
+                ),
+            },
+            "teltik_v3_cross_check": {
+                "model_v3_m_s": v3_teltik_model_m_s,
+                "teltik_cfd_v3_m_s": TELTIK_V3_M_S,
+                "condition": f"Mach {TELTIK_MACH} / {TELTIK_ALTITUDE_M:.0f} m",
+                "delta_frac": v3_teltik_delta_frac,
+                "note": (
+                    "Model V3 is the fully-expanded 1-D isentropic exit "
+                    "velocity (Th2, real losses); Teltik 2024 CFD "
+                    "~1047 m/s (assumptions A15) reflects the actual "
+                    "(near-cylindrical, expansion_ratio 1.0) geometry, so "
+                    "the 1-D fully-expanded value is expected to be higher. "
+                    "Delta quantified, agreement NOT forced (cf. "
+                    "assumptions A3: CFD vs MATLAB 20-30% open discrepancy)."
+                ),
+            },
+            "nozzle_area_ratio_note": (
+                "Model implies A3/A21 ~ "
+                f"{area_ratio_model:.2f} (fully-expanded real Th2 exit over "
+                "the dynamic choked throat). vehicle_config.yaml "
+                "nozzle_area_ratio=4.0 is the DESIGN INTENT; the Fusion v6 "
+                "CAD nozzle is a cylindrical exit stub (expansion_ratio "
+                "1.0, 'full ramjet engine NOT modeled'). All three are "
+                "logged so the CAD-vs-design gap is quantified, not "
+                "silently resolved (assumptions A10)."
+            ),
+            "combustor_risk_baseline": (
+                "Tt2=2000 K is a PLACEHOLDER chosen BELOW the ~2400 K "
+                "flame-holder cavity risk figure (assumptions A4); "
+                "combustor design is BLOCKED pending flame-holder "
+                "relocation / injector atomization redesign. Fusion v6 "
+                "lists the flame_holder material as STEEL, contradicting "
+                "the 'aluminium' risk note -- flagged for human review, "
+                "NOT resolved here."
+            ),
+            "reference_model_disclosure": (
+                "Grzywka 2022 station model (1-2-21-3, pi_CC=0.8924, "
+                "pi_nozzle=0.97). Complementary to the Mattingly-style "
+                "ramjet_cycle (0-2-4-9) model; single-method L2 result "
+                "pending CFD/MATLAB dual-check (assumptions A3)."
+            ),
+            "assumptions": [
+                f"Grzywka loss coefficients pi_CC={self._pi_cc}, "
+                f"pi_nozzle={self._pi_nozzle} (assumptions A13).",
+                f"Combustion efficiency eta_b={self._eta_b} is a "
+                "placeholder shared with ramjet_cycle.",
+                "Nozzle throat (station 21) choked (Ma=1) at all "
+                "conditions; A21 solved dynamically from continuity, "
+                "never hard-coded.",
+                "All three thrust models fully expand to ambient p0 "
+                "(p3=p0); loss level enters only via the delivered nozzle "
+                "total pressure.",
+                "Full mass-flow capture at the design Mach "
+                "(mdot_air=rho0*u0*A_capture), consistent with "
+                "inlet_performance / ramjet_cycle.",
+                "Two-gas calorically-perfect model (cold/hot cp,gamma); "
+                "no dissociation or variable-cp beyond the two fixed sets.",
+            ],
+        }
+
+        results = AnalysisResults(
+            name=self.name, fidelity=self.fidelity, data=data, metadata=metadata
+        )
+        if not self.validate_results(results):
+            raise RuntimeError(
+                f"Grzywka combustor/nozzle results failed physical validation: "
+                f"{results.data}"
+            )
+        return results
+
+    def validate_results(self, results: AnalysisResults) -> bool:
+        """Sanity-check the Grzywka cycle results.
+
+        Checks: the three thrust models are all positive and obey the
+        physical hierarchy ``Thi >= Th1 >= Th2``; the choked throat area
+        and exit area are positive; ``Ma21 == 1``; the fuel-air ratio is
+        in a physically sensible kerosene-air range (0, 0.15); Isp in the
+        broad hydrocarbon band per project rules; and the combustor exit
+        temperature stays below the material sanity ceiling.
+
+        Args:
+            results: Results to validate.
+
+        Returns:
+            True if all physical sanity checks pass.
+        """
+        required = {
+            "Thi_N",
+            "Th1_N",
+            "Th2_N",
+            "A21_throat_m2",
+            "A3_exit_m2",
+            "Ma21",
+            "f_fuel_air",
+            "isp_s",
+            "tt2_K",
+        }
+        if not required.issubset(results.data):
+            return False
+        thi, th1, th2 = results["Thi_N"], results["Th1_N"], results["Th2_N"]
+        if not (thi > 0.0 and th1 > 0.0 and th2 > 0.0):
+            return False
+        # Core physical hierarchy (1e-6 N slack for float noise).
+        if not (thi >= th1 - 1e-6 and th1 >= th2 - 1e-6):
+            return False
+        if not (results["A21_throat_m2"] > 0.0 and results["A3_exit_m2"] > 0.0):
+            return False
+        if abs(results["Ma21"] - 1.0) > 1e-9:
+            return False
+        if not (0.0 < results["f_fuel_air"] < 0.15):
+            return False
+        if not (400.0 < results["isp_s"] < 3000.0):
+            return False
+        if not (0.0 < results["tt2_K"] < COMBUSTOR_TEMP_CEILING_K):
+            return False
+        return True
+
+
+def _build_output_dict(results: AnalysisResults) -> dict[str, Any]:
+    """Flatten an AnalysisResults into a JSON-serializable output dict."""
+    out: dict[str, Any] = dict(results.data)
+    out["eta_inlet_source"] = results.metadata["eta_inlet_source"]
+    out["station_table"] = results.metadata["station_table"]
+    out["thrust_model_hierarchy"] = results.metadata["thrust_model_hierarchy"]
+    out["brayton_t2_cross_check"] = results.metadata["brayton_t2_cross_check"]
+    out["teltik_v3_cross_check"] = results.metadata["teltik_v3_cross_check"]
+    out["nozzle_area_ratio_note"] = results.metadata["nozzle_area_ratio_note"]
+    out["reference_model_disclosure"] = results.metadata["reference_model_disclosure"]
+    out["assumptions"] = results.metadata["assumptions"]
+    out["fidelity"] = results.fidelity.name
+    return out
+
+
+def main() -> None:
+    """Run the design-point Grzywka cycle, save JSON and print a summary."""
+    analysis = GrzywkaCombustorNozzleAnalysis()
+    analysis.setup(mach0=MACH_DESIGN, altitude_m=DESIGN_ALTITUDE_M)
+    results = analysis.execute()
+    output = _build_output_dict(results)
+
+    module_dir = Path(__file__).resolve().parent
+    json_path = module_dir / "combustor_nozzle_cycle_results.json"
+    with open(json_path, "w", encoding="utf-8") as f:
+        json.dump(output, f, indent=2)
+
+    print("=== Grzywka combustor+nozzle cycle (stations 1-2-21-3) ===")
+    print(f"Design Mach: {MACH_DESIGN}, altitude: {DESIGN_ALTITUDE_M} m ISA")
+    print(f"eta_inlet: {output['eta_inlet']:.4f} (source: {output['eta_inlet_source'] if 'eta_inlet_source' in output else 'n/a'})")
+    print(f"pi_CC: {output['pi_cc']}, pi_nozzle: {output['pi_nozzle']}")
+    print(f"Tt1: {output['tt1_K']:.2f} K, Tt2: {output['tt2_K']:.2f} K, f: {output['f_fuel_air']:.4f}")
+    print(f"Thi (ideal):           {output['Thi_N']:.1f} N")
+    print(f"Th1 (pi_CC):           {output['Th1_N']:.1f} N")
+    print(f"Th2 (pi_CC+pi_nozzle): {output['Th2_N']:.1f} N  <- nominal")
+    print(f"Dynamic throat A21: {output['A21_throat_m2']:.5f} m^2 (D21 {output['D21_throat_m']:.4f} m, Ma21 {output['Ma21']:.1f})")
+    print(f"Exit A3: {output['A3_exit_m2']:.5f} m^2, V3(real): {output['V3_m_s']:.1f} m/s, Isp: {output['isp_s']:.1f} s")
+    b = output["brayton_t2_cross_check"]
+    print(f"Brayton T2 cross-check: {b['brayton_estimate_tt2_K']:.1f} K vs {b['station_model_tt2_K']:.1f} K (delta {b['delta_frac']*100:+.1f}%, >5%={b['exceeds_5pct']})")
+    t = output["teltik_v3_cross_check"]
+    print(f"V3 vs Teltik CFD ({t['condition']}): {t['model_v3_m_s']:.1f} vs {t['teltik_cfd_v3_m_s']:.1f} m/s (delta {t['delta_frac']*100:+.1f}%)")
+    print(f"Nozzle area ratio A3/A21 model: {output['nozzle_area_ratio_model']:.2f} | YAML design 4.0 | CAD cylindrical 1.0")
+    print(f"\nJSON written to: {json_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/analyses/propulsion/combustor_nozzle_cycle_results.json
+++ b/analyses/propulsion/combustor_nozzle_cycle_results.json
@@ -1,0 +1,93 @@
+{
+  "Thi_N": 12467.629227569254,
+  "Th1_N": 12107.907170221897,
+  "Th2_N": 12008.96485105987,
+  "thrust_nominal_N": 12008.96485105987,
+  "V3i_m_s": 1503.272177096609,
+  "V3_1_m_s": 1480.5729400996183,
+  "V3_2_m_s": 1474.3294665460296,
+  "V3_m_s": 1474.3294665460296,
+  "A21_throat_m2": 0.05064881693023091,
+  "D21_throat_m": 0.2539450267471718,
+  "A3_exit_m2": 0.12360278596279858,
+  "Ma21": 1.0,
+  "Ma3": 2.3186664603021465,
+  "f_fuel_air": 0.04482144410219242,
+  "isp_s": 1801.2969819334419,
+  "mdot_air_kg_s": 15.167490506864516,
+  "mdot_fuel_kg_s": 0.6798288279239622,
+  "mdot_exit_kg_s": 15.847319334788477,
+  "tt1_K": 502.0875,
+  "tt2_K": 2000.0,
+  "pt1_Pa": 394799.6886002815,
+  "pt2_Pa": 352319.2421068912,
+  "eta_inlet": 0.8740657315001767,
+  "pi_cc": 0.8924,
+  "pi_nozzle": 0.97,
+  "eta_b": 0.95,
+  "mach0": 2.5,
+  "altitude_m": 10000.0,
+  "nozzle_area_ratio_model": 2.440388412883607,
+  "nozzle_area_ratio_design_yaml": 4.0,
+  "nozzle_area_ratio_cad_cylindrical": 1.0,
+  "station_table": [
+    {
+      "station": "1_combustor_inlet",
+      "total_temperature_K": 502.0875,
+      "total_pressure_Pa": 394799.6886002815
+    },
+    {
+      "station": "2_combustor_exit",
+      "total_temperature_K": 2000.0,
+      "total_pressure_Pa": 352319.2421068912
+    },
+    {
+      "station": "21_nozzle_throat_choked",
+      "mach": 1.0,
+      "static_temperature_K": 1716.7381974248929,
+      "static_pressure_Pa": 190380.64115533256,
+      "velocity_m_s": 809.2597157610455,
+      "area_m2": 0.05064881693023091,
+      "diameter_m": 0.2539450267471718
+    },
+    {
+      "station": "3_nozzle_exit_real_Th2",
+      "mach": 2.3186664603021465,
+      "static_temperature_K": 1059.841100378071,
+      "static_pressure_Pa": 26435.887460311165,
+      "velocity_m_s": 1474.3294665460296,
+      "area_m2": 0.12360278596279858
+    }
+  ],
+  "thrust_model_hierarchy": {
+    "Thi_N": 12467.629227569254,
+    "Th1_N": 12107.907170221897,
+    "Th2_N": 12008.96485105987,
+    "note": "Grzywka Sec. 6.2.2 three-thrust decomposition. Thi: ideal, no losses (pi_CC=pi_nozzle=1), fully expanded. Th1: combustor loss pi_CC only. Th2: real, both pi_CC and pi_nozzle (nominal for downstream cruise wiring). Hierarchy Thi>=Th1>=Th2 holds by construction (same mdot/Tt1/Tt2/f; only the delivered nozzle total pressure differs)."
+  },
+  "brayton_t2_cross_check": {
+    "station_model_tt2_K": 2000.0,
+    "brayton_estimate_tt2_K": 2250.7045221210733,
+    "delta_frac": 0.12535226106053665,
+    "exceeds_5pct": true,
+    "note": "Independently-coded single-gas (cold-cp) Brayton heat-addition estimate of Tt2 vs the station model's Tt2. Delta driven mainly by cold-cp vs hot-cp choice. Logged as an OPEN ITEM if >5%; NOT a validation failure (repo method-discrepancy convention)."
+  },
+  "teltik_v3_cross_check": {
+    "model_v3_m_s": 1474.3294665460296,
+    "teltik_cfd_v3_m_s": 1047.0,
+    "condition": "Mach 2.5 / 6000 m",
+    "delta_frac": 0.4081465774078602,
+    "note": "Model V3 is the fully-expanded 1-D isentropic exit velocity (Th2, real losses); Teltik 2024 CFD ~1047 m/s (assumptions A15) reflects the actual (near-cylindrical, expansion_ratio 1.0) geometry, so the 1-D fully-expanded value is expected to be higher. Delta quantified, agreement NOT forced (cf. assumptions A3: CFD vs MATLAB 20-30% open discrepancy)."
+  },
+  "nozzle_area_ratio_note": "Model implies A3/A21 ~ 2.44 (fully-expanded real Th2 exit over the dynamic choked throat). vehicle_config.yaml nozzle_area_ratio=4.0 is the DESIGN INTENT; the Fusion v6 CAD nozzle is a cylindrical exit stub (expansion_ratio 1.0, 'full ramjet engine NOT modeled'). All three are logged so the CAD-vs-design gap is quantified, not silently resolved (assumptions A10).",
+  "reference_model_disclosure": "Grzywka 2022 station model (1-2-21-3, pi_CC=0.8924, pi_nozzle=0.97). Complementary to the Mattingly-style ramjet_cycle (0-2-4-9) model; single-method L2 result pending CFD/MATLAB dual-check (assumptions A3).",
+  "assumptions": [
+    "Grzywka loss coefficients pi_CC=0.8924, pi_nozzle=0.97 (assumptions A13).",
+    "Combustion efficiency eta_b=0.95 is a placeholder shared with ramjet_cycle.",
+    "Nozzle throat (station 21) choked (Ma=1) at all conditions; A21 solved dynamically from continuity, never hard-coded.",
+    "All three thrust models fully expand to ambient p0 (p3=p0); loss level enters only via the delivered nozzle total pressure.",
+    "Full mass-flow capture at the design Mach (mdot_air=rho0*u0*A_capture), consistent with inlet_performance / ramjet_cycle.",
+    "Two-gas calorically-perfect model (cold/hot cp,gamma); no dissociation or variable-cp beyond the two fixed sets."
+  ],
+  "fidelity": "LEVEL_2"
+}

--- a/analyses/propulsion/inlet_performance.py
+++ b/analyses/propulsion/inlet_performance.py
@@ -1,4 +1,4 @@
-# MELprop-IADE | analyses.propulsion.inlet_performance | v0.1.0
+# MELprop-IADE | analyses.propulsion.inlet_performance | v0.2.0
 """Low-order axisymmetric conical-spike inlet performance analysis.
 
 Models the Project B stage-2 ramjet intake (Fusion Assembly v6: conical
@@ -982,6 +982,252 @@ class MultiConeInletPerformanceAnalysis(BaseAnalysis):
         ):
             return False
         return True
+
+
+# --------------------------------------------------------------------------
+# Movable (translating-centerbody) spike inlet — actuation model
+#
+# The stage-2 ramjet uses a MOVABLE conical spike: as the vehicle
+# accelerates through the supersonic range the oblique-shock angle beta
+# grows shallower with Mach (see oblique_shock_beta_rad), so the shock
+# foot walks off the cowl lip unless the centerbody is TRANSLATED axially
+# to reposition it. This is standard supersonic variable-geometry-inlet
+# practice — the same physical idea as the translating spikes of the
+# SR-71 and F-15/F-16-class inlets (Seddon & Goldsmith, *Intake
+# Aerodynamics*, 2nd ed. 1999, Ch. 6 "Variable geometry"; Anderson,
+# *Modern Compressible Flow*, 3rd ed., Ch. 4 on the beta(M) dependence
+# that motivates the translation schedule).
+#
+# This section models the ACTUATION HARDWARE and the TRANSITION SEQUENCE
+# (cone position vs time as the vehicle changes Mach), NOT the shock
+# aerodynamics itself (that is the oblique/normal/multi-cone chain above).
+# It mirrors combustor_nozzle_cycle.py's dynamic-geometry-vs-flight-
+# condition style: the commanded cone position is a function of the
+# flight state, recorded against (Mach, V, H) rather than hard-coded.
+#
+# NO Grzywka MATLAB actuator data exists in this repo (confirmed:
+# docs/assumptions.md notes the Grzywka MATLAB model itself is not
+# vendored — only its derived loss coefficients A13 are; the Fusion v6
+# inlet_cone_spike block carries geometry only, no actuation fields). The
+# four actuation parameters below are therefore TODO_PHYSICAL_PARAM
+# placeholders set to the CENTRE of a documented typical range for a
+# small (sub-1 kg centerbody) supersonic-spike linear actuator of this
+# ~0.29 m cone scale; each range and its analogous-hardware reasoning is
+# given in MovableInletActuation. They must be replaced with real
+# actuator/CAD data before any control-loop or mass-budget use.
+# --------------------------------------------------------------------------
+
+#: Freestream Mach at which the spike is fully RETRACTED (subsonic /
+#: pre-start reference position, cone_position = 0 mm). Below start the
+#: inlet has no oblique-shock system to position, so this is the stow datum.
+MACH_SPIKE_RETRACTED: float = 0.0
+
+#: Freestream Mach at which the spike is fully EXTENDED (design cruise
+#: shock-on-lip position, cone_position = cone_travel_mm). Ties the stroke
+#: endpoints to the Mach-2.5 design point (MACH_DESIGN).
+MACH_SPIKE_DESIGN: float = MACH_DESIGN
+
+
+@dataclass
+class MovableInletActuation:
+    """Actuation parameters for the translating-centerbody spike inlet.
+
+    Kinematic / hardware description of the linear actuator that
+    translates the conical spike to keep the oblique-shock system on the
+    cowl lip across the supersonic Mach range. All four fields are
+    ``TODO_PHYSICAL_PARAM`` placeholders (no Grzywka MATLAB actuator data
+    is vendored in this repo — see the section banner above): each default
+    is the centre of a documented typical range for a small supersonic-
+    spike linear actuator sized to this ~0.293 m / sub-1 kg steel
+    centerbody, NOT a measured or CAD-sourced value.
+
+    TODO_PHYSICAL_PARAM ranges and analogous-hardware reasoning:
+
+    * ``screw_lead_mm`` — axial travel per screw revolution. Compact
+      ball-/lead-screw linear actuators of this class run leads of about
+      1-10 mm/rev (low leads trade speed for holding load / positioning
+      resolution; e.g. common 2 mm and 5 mm-lead miniature ball screws).
+      Typical range **1-10 mm/rev**; default 2.0 (fine-positioning end,
+      favouring shock-position accuracy over slew speed).
+    * ``motor_torque_Nm`` — actuator/motor output torque. A sub-1 kg
+      centerbody with modest supersonic pressure loads is within the
+      band of a NEMA-17-to-NEMA-23-class stepper or small BLDC/servo
+      (~0.1-2 N*m continuous; NEMA-17 ~0.4 N*m, NEMA-23 ~1-2 N*m).
+      Typical range **0.1-2 N*m**; default 0.5.
+    * ``cone_travel_mm`` — total axial stroke. Translating spikes
+      reposition the shock foot over a stroke that is roughly 10-30% of
+      the cone length; for the 293 mm Fusion v6 spike that is about
+      30-90 mm. Typical range **30-90 mm**; default 50 (~17% of cone
+      length).
+    * ``transition_time_s`` — time for one full stroke. Variable-geometry
+      inlet actuators complete full travel in of order 1-10 s (small
+      electric linear actuators run ~5-25 mm/s, i.e. a 50 mm stroke in
+      ~2-10 s) — fast enough to track boost-phase acceleration without
+      the inertia of a heavy hydraulic ram. Typical range **1-10 s**;
+      default 3.0. Sets the constant slew rate
+      ``cone_travel_mm / transition_time_s``.
+
+    Attributes:
+        screw_lead_mm: Linear-actuator screw lead [mm/rev].
+        motor_torque_Nm: Actuator output torque [N*m].
+        cone_travel_mm: Total axial stroke of the centerbody [mm].
+        transition_time_s: Time to traverse a full ``cone_travel_mm``
+            stroke [s].
+    """
+
+    #: TODO_PHYSICAL_PARAM — typical range 1-10 mm/rev (see class docstring).
+    screw_lead_mm: float = 2.0
+    #: TODO_PHYSICAL_PARAM — typical range 0.1-2 N*m (see class docstring).
+    motor_torque_Nm: float = 0.5
+    #: TODO_PHYSICAL_PARAM — typical range 30-90 mm (see class docstring).
+    cone_travel_mm: float = 50.0
+    #: TODO_PHYSICAL_PARAM — typical range 1-10 s (see class docstring).
+    transition_time_s: float = 3.0
+
+    @property
+    def slew_rate_mm_s(self) -> float:
+        """Constant actuator slew rate [mm/s] = stroke / full-stroke time.
+
+        Returns:
+            Linear translation speed of the centerbody [mm/s].
+        """
+        return self.cone_travel_mm / self.transition_time_s
+
+    def cone_position_for_mach(self, mach: float) -> float:
+        """Commanded cone position for a given freestream Mach number.
+
+        Linear schedule between the retracted datum (``MACH_SPIKE_RETRACTED``
+        -> 0 mm) and the design shock-on-lip position (``MACH_SPIKE_DESIGN``
+        -> ``cone_travel_mm``), clamped to the stroke limits outside that
+        band. A monotone map is the correct low-order behaviour: the
+        oblique-shock angle falls monotonically with Mach, so the
+        translation required to hold the shock on the lip is monotone in
+        Mach too. (A trajectory- or beta-scheduled non-linear map is a
+        deliberate future refinement; not warranted at this fidelity.)
+
+        Args:
+            mach: Freestream Mach number (>= 0).
+
+        Returns:
+            Commanded axial cone position [mm], in ``[0, cone_travel_mm]``.
+        """
+        span = MACH_SPIKE_DESIGN - MACH_SPIKE_RETRACTED
+        frac = (mach - MACH_SPIKE_RETRACTED) / span
+        frac = min(1.0, max(0.0, frac))
+        return frac * self.cone_travel_mm
+
+    def metadata(self) -> dict[str, Any]:
+        """Actuation parameters plus TODO_PHYSICAL_PARAM provenance.
+
+        Returns:
+            Dict of the four actuation fields, the derived slew rate, and
+            a ``todo_physical_params`` list naming every field that is a
+            placeholder (with its documented typical range) so downstream
+            consumers can assert the values are flagged rather than trust
+            their magnitudes.
+        """
+        return {
+            "screw_lead_mm": self.screw_lead_mm,
+            "motor_torque_Nm": self.motor_torque_Nm,
+            "cone_travel_mm": self.cone_travel_mm,
+            "transition_time_s": self.transition_time_s,
+            "slew_rate_mm_s": self.slew_rate_mm_s,
+            "todo_physical_params": {
+                "screw_lead_mm": "TODO_PHYSICAL_PARAM; typical 1-10 mm/rev",
+                "motor_torque_Nm": "TODO_PHYSICAL_PARAM; typical 0.1-2 N*m",
+                "cone_travel_mm": "TODO_PHYSICAL_PARAM; typical 30-90 mm",
+                "transition_time_s": "TODO_PHYSICAL_PARAM; typical 1-10 s",
+            },
+            "source": (
+                "No Grzywka MATLAB actuator data in repo; defaults are the "
+                "centre of documented typical small-spike-actuator ranges "
+                "(see MovableInletActuation docstring). Replace with real "
+                "actuator / CAD data before control-loop or mass-budget use."
+            ),
+        }
+
+
+#: Default actuation set used when no explicit MovableInletActuation is
+#: supplied (all fields TODO_PHYSICAL_PARAM — see the class docstring).
+DEFAULT_INLET_ACTUATION: MovableInletActuation = MovableInletActuation()
+
+
+def compute_transition_sequence(
+    mach_current: float,
+    mach_target: float,
+    velocity_m_s: float,
+    altitude_m: float,
+    actuation: MovableInletActuation = DEFAULT_INLET_ACTUATION,
+    n_samples: int = 11,
+) -> list[tuple[float, float]]:
+    """Time history of the cone translation for a Mach transition.
+
+    Builds the ``(time_s, cone_position_mm)`` schedule that moves the
+    centerbody from its current-Mach position to its target-Mach position
+    using a **constant-velocity (linear) profile** at the actuator slew
+    rate ``cone_travel_mm / transition_time_s``. A linear profile is
+    chosen deliberately over a trapezoidal one: a lead-screw driven at a
+    fixed motor speed IS a constant-velocity actuator, the accel/decel
+    ramps of a trapezoidal profile need a jerk/accel limit we have no data
+    for (all four actuation params are TODO_PHYSICAL_PARAM), and the extra
+    complexity buys nothing at this fidelity. Both a full-stroke transition
+    (M0 -> M2.5, startup) and a partial one take time proportional to the
+    position delta, so the duration is
+    ``|dx| / cone_travel_mm * transition_time_s``.
+
+    Mirrors combustor_nozzle_cycle.py's dynamic-geometry-vs-flight-
+    condition style: the endpoint positions come from
+    :meth:`MovableInletActuation.cone_position_for_mach` (a function of
+    Mach, which sets the shock geometry). ``velocity_m_s`` and
+    ``altitude_m`` are the flight-condition context at which the
+    transition is commanded and are accepted for interface parity with the
+    (V, H)-keyed dynamic-geometry convention; at this L0 kinematic
+    fidelity they do not alter the timing (a V/H-dependent slew schedule
+    is a documented future refinement).
+
+    Args:
+        mach_current: Freestream Mach at the start of the transition (>= 0).
+        mach_target: Freestream Mach at the end of the transition (>= 0).
+        velocity_m_s: Freestream velocity at command time [m/s] (context).
+        altitude_m: Flight altitude at command time [m] (context).
+        actuation: Actuation hardware description. Defaults to
+            ``DEFAULT_INLET_ACTUATION`` (all fields TODO_PHYSICAL_PARAM).
+        n_samples: Number of evenly-spaced time samples, including both
+            endpoints (>= 2).
+
+    Returns:
+        List of ``(time_s, cone_position_mm)`` tuples, ordered by time
+        from 0.0 to the transition duration. Cone position varies
+        monotonically from the current-Mach to the target-Mach position.
+        A zero-length move (identical positions) returns a single
+        ``[(0.0, position)]`` sample.
+
+    Raises:
+        ValueError: If ``n_samples < 2`` or either Mach is negative.
+    """
+    if n_samples < 2:
+        raise ValueError(f"n_samples must be >= 2, got {n_samples}")
+    if mach_current < 0.0 or mach_target < 0.0:
+        raise ValueError(
+            f"Mach numbers must be >= 0, got current={mach_current}, "
+            f"target={mach_target}"
+        )
+
+    pos_start_mm = actuation.cone_position_for_mach(mach_current)
+    pos_end_mm = actuation.cone_position_for_mach(mach_target)
+    delta_mm = pos_end_mm - pos_start_mm
+
+    if delta_mm == 0.0:
+        return [(0.0, pos_start_mm)]
+
+    duration_s = abs(delta_mm) / actuation.slew_rate_mm_s
+    sequence: list[tuple[float, float]] = []
+    for i in range(n_samples):
+        frac = i / (n_samples - 1)
+        time_s = frac * duration_s
+        position_mm = pos_start_mm + frac * delta_mm
+        sequence.append((time_s, position_mm))
+    return sequence
 
 
 def sweep_eta_inlet(

--- a/doc/ramP/analysis_status.md
+++ b/doc/ramP/analysis_status.md
@@ -26,6 +26,7 @@ Status legend: **DONE** (implemented + run) · **STUB** (scaffold + TODO) ·
 | 16 | Combustor+nozzle Grzywka model (CC→NT→NE, Thi/Th1/Th2) | `analyses/propulsion/combustor_nozzle_cycle.py` | **BLOCKED_BY_BUDGET** | propulsion-designer | 2026-07-09 |
 | 17 | Cruise wiring to Grzywka model (Night-2 Phase 3b) | `workflows/ramp_staged_mission.py` | BLOCKED_BY_BUDGET | mission-planner | 2026-07-09 |
 | 18 | Movable-inlet actuation params (Night-2 Phase 4b) | `analyses/propulsion/inlet_performance.py` | BLOCKED_BY_BUDGET | propulsion-designer | 2026-07-09 |
+| 19 | Stability reconciliation (geometry audit + fin-span sensitivity sweep, Night-3 Phase 5) | `doc/ramP/stability_reconciliation.md` | DONE | aero-analyst | 2026-07-09 |
 
 ## Night-2 checkpoint (2026-07-09, budget guard at 80%)
 

--- a/doc/ramP/stability_reconciliation.md
+++ b/doc/ramP/stability_reconciliation.md
@@ -1,0 +1,218 @@
+# ramP — Stability Discrepancy Reconciliation (Geometry Audit + Sensitivity)
+
+**Date:** 2026-07-09 (Night-3, Phase 5)
+**Author:** aero-analyst subagent (MELprop-IADE)
+**Scope:** Analysis and documentation only. No vehicle config/geometry YAML and
+no code under `analyses/stability/` were modified — this file is the only
+write. All numbers below were produced by calling the existing
+`analyses/stability/barrowman_stability.py` functions (`load_geometry`,
+`compute_stability_at_mach`) directly, read-only, from a throwaway script;
+none of the Barrowman math was reimplemented.
+
+**Prerequisite reading (not reproduced here):**
+- `doc/ramP/stability_margin_report.md` — Phase 0b writeup establishing the
+  sign-flip discrepancy (Barrowman +8.99 cal vs Teltik 2024 CFD −2.75 cal at
+  Ma 2.5).
+- `docs/assumptions.md`, row **A15** — numeric register entry for the same
+  discrepancy.
+- `doc/ramP/static_margin_review.md` (Night 1) — origin of the "~7-8x
+  fin-span reduction would restore 1.5-2 cal" hypothesis, computed at the
+  M=0 anchor condition.
+
+---
+
+## 1. Geometry-field audit — what feeds the Barrowman CP
+
+`load_geometry()` in `analyses/stability/barrowman_stability.py` (lines
+189–223) reads the following exact YAML keys from
+`vehicles/ramjet_rocket/vehicle_config.yaml` into the `RocketGeometry`
+dataclass used by every downstream CP/CN_alpha formula:
+
+| YAML key (in `vehicle_config.yaml`) | `RocketGeometry` field | Role in CP computation |
+|---|---|---|
+| `body.diameter_m` | `d_ref_m` | Reference diameter for all `CN_alpha` normalization and the caliber (`SM_cal`) denominator. |
+| `body.nose_length_m` | `nose_length_m` | Nose `CN_alpha`/CP (`nose_cn_alpha_and_cp`), scaled by `NOSE_CP_FACTOR = 0.466`. |
+| `body.nose_diameter_m` | `nose_base_diameter_m` | Nose area-ratio `CN_alpha`; also the small-end radius of the nose→body transition (shoulder) term. |
+| `body.total_length_m` | `total_length_m` | Overall length; also fixes the fin-root leading-edge axial position via `fin_root_le_x_m = total_length_m − fin_root_chord_m` (fins assumed flush with the aft end — a coded assumption, not a YAML field). |
+| `fins.count` | `fin_count` | Linear multiplier `N` on fin `CN_alpha` (`fin_cn_alpha_base_and_cp`). |
+| `fins.span_m` | `fin_span_m` | Enters fin `CN_alpha` as `(s/d)^2` (squared) and the body-fin interference factor `Kfb = 1 + R/(s+R)` — the single most sensitive geometry input to CP, since fins alone already carry 97.1% of total `CN_alpha` per the Night-1 breakdown. |
+| `fins.chord_root_m` | `fin_root_chord_m` | Fin `CN_alpha` denominator term and fin-CP `x_from_root_le` offset. |
+| `fins.chord_tip_m` | `fin_tip_chord_m` | Same as above (taper terms). |
+| `fins.sweep_deg` | `fin_sweep_deg` | Leading-edge sweep distance `l_m = s·tan(sweep)`, feeds both `CN_alpha` and fin-CP location. |
+| `mass_properties.cg_from_nose_m` | `cg_from_nose_m` | Not a CP input, but is the other half of `static_margin_cal = (x_cp − cg)/d_ref`. |
+
+**Not sourced from either YAML file at all:** `TRANSITION_LENGTH_M = 0.10`
+(module-level constant, line 88) — the nose→body shoulder length used by
+`transition_cn_alpha_and_cp` is a hardcoded engineering assumption ("short"),
+explicitly flagged in the module's own `_assumptions()` output, because no
+transition length is present in the Fusion export. Nose fineness itself
+(`nose_length_m / nose_base_diameter_m = 0.293/0.150 = 1.953`) and overall
+fineness (`total_length_m / d_ref_m = 4.377/0.250 = 17.51`) are both derived
+from the audited keys above, not separate YAML fields.
+
+Cross-check against `fusion_extraction_v6.yaml` (the raw, "do not hand-edit"
+source of truth): `fins.fin_properties.span_m = 0.6685`,
+`chord_root_m = chord_tip_m = 0.1768`, `sweep_le_degrees = sweep_te_degrees =
+0.0`; `body.nose_cone.length_m = 0.293`, `base_diameter_m = 0.150`;
+`structure.total_length_m = 4.377`; `center_of_gravity.y_m = 1.6084`. All
+values in `vehicle_config.yaml` match the raw extraction 1:1 — the
+reconciled YAML has not introduced a transcription error relative to the raw
+export; if an error exists, it is upstream, in the Fusion extraction itself
+or in what CAD feature was measured.
+
+## 2. Confirmed vs. suspect fields
+
+| Field | YAML value | Flag status | Evidence |
+|---|---|---|---|
+| `body.diameter_m` | 0.250 m | Confirmed-good | Comment: "Fusion-verified body diameter"; `fusion_extraction_v6.yaml` `extraction.confidence.dimensions: "VERY HIGH"`. |
+| `body.nose_length_m` / `nose_diameter_m` | 0.293 m / 0.150 m | Confirmed (self-declared) | Same "VERY HIGH" dimensions confidence block; internally consistent with nose fineness ratio ~1.95 (physically plausible cone). |
+| `body.total_length_m` | 4.377 m | Confirmed (self-declared) | Cross-checked in the extraction's own "CORRECTIONS LOG" (`axis_correction`: "Booster 2.089m now fits in total 4.377m"). |
+| `mass_properties.cg_from_nose_m` | 1.6084 m | Confirmed (self-declared) | `extraction.confidence.center_of_gravity: "VERY HIGH (verified by component breakdown)"`. |
+| `fins.count`, `sweep_deg`, `chord_root_m`/`chord_tip_m` | 4, 0.0°, 0.1768 m | Confirmed (self-declared), **not independently flagged as suspect anywhere** | No `SZACOWANY` tag; not mentioned in Night-1/A15 discussion. |
+| **`fins.span_m`** | **0.6685 m** | **Suspect** — but *not* via any explicit `SZACOWANY`/estimated tag in either YAML file | Flagged only in `doc/ramP/static_margin_review.md` and `doc/ramP/analysis_status.md` ("Fin span suspect... likely Fusion export artifact"), inferred *indirectly* from the physically implausible resulting static margin (10+ cal at M=0, +8.99 cal at Ma 2.5) and from this exact extraction pipeline's own history of one already-caught cm/mm unit bug (`fusion_extraction_v6.yaml` → `corrections.unit_system_fix`). |
+| `body.max_diameter_m` | 0.639 m | **Internally inconsistent, not currently used by Barrowman** | Not read by `load_geometry()` at all. See Section 3 note below — it is numerically hard to reconcile with `fins.span_m = 0.6685 m` if both describe the same physical vehicle. |
+
+Note the asymmetry: propulsion fields in `vehicle_config.yaml`
+(`stage_1.propulsion.isp_*`, `thrust_*`, `burn_time_s`, etc.) carry explicit
+`# SZACOWANY` comments. **No geometry field carries an equivalent explicit
+flag** — every CP-feeding geometry field is labeled by the extraction as
+"Fusion" / "VERY HIGH confidence". The fin-span suspicion is therefore an
+*inferred*, not a *declared*, data-quality flag, which is precisely why it
+needs a human CAD check rather than a code fix: the file offers no signal by
+itself.
+
+## 3. Sensitivity sweep — `fin_span_m` at Ma 2.5
+
+Sweeping `fins.span_m` ±20% around the current 0.6685 m value (5 points),
+holding every other geometry field fixed, and calling
+`compute_stability_at_mach(geometry, mach=2.5)` directly:
+
+| Δspan | `fin_span_m` [m] | CP [m from nose] | Static margin [cal] |
+|---|---|---|---|
+| −20% | 0.5348 | 3.6808 | **8.290** |
+| −10% | 0.6017 | 3.7794 | **8.684** |
+| 0% (current) | 0.6685 | 3.8548 | **8.986** |
+| +10% | 0.7354 | 3.9137 | **9.221** |
+| +20% | 0.8022 | 3.9603 | **9.408** |
+
+(CG = 1.6084 m, d_ref = 0.250 m throughout; the 0% row reproduces the
++8.986 ≈ +8.99 cal figure from `stability_margin_report.md` exactly, which
+is a useful internal cross-check that the sweep script is calling the real
+code path correctly.)
+
+**Reading:** over the full ±20% band the static margin stays positive and
+moves only from 8.29 to 9.41 cal — a swing of ~1.1 cal. **±20% alone comes
+nowhere close to flipping the sign**, let alone reaching the CFD-implied
+−2.75 cal. The local slope is roughly **+4.18 cal per meter of span** at
+this Mach, i.e. the margin is fin-span-sensitive but not steep enough for a
+plausible small measurement error to explain a 9-12 caliber CP gap.
+
+Extending the same bisection (still calling `compute_stability_at_mach`
+directly, no reimplementation) to find what span *would* close the gap at
+Ma 2.5, holding everything else fixed:
+
+| Target | Span needed [m] | Reduction factor vs. current 0.6685 m |
+|---|---|---|
+| SM = 0 (sign flip) | 0.1391 m | **4.80x** |
+| SM = +1.5 cal (healthy band, low end) | 0.1732 m | **3.86x** |
+| SM = +2.0 cal (healthy band, high end) | 0.1857 m | **3.60x** |
+
+This is smaller than the Night-1 "~7-8x" figure — but that figure was
+derived at the **M=0** anchor condition in `static_margin_review.md`, not at
+Ma 2.5. The two are not directly comparable: `fin_mach_correction_factor()`
+scales the fin `CN_alpha` differently at each Mach (Prandtl-Glauert at M=0
+vs. the Ackeret supersonic branch at M=2.5), so the span reduction needed to
+reach a given caliber target is itself Mach-dependent. **This is a
+discrepancy the team should be aware of, not one this analysis resolves**:
+the correct question is not "what single span value fixes the margin" but
+"does a single corrected span produce an acceptable margin across the whole
+flight Mach range," which requires a full Mach sweep at the corrected span,
+not addressed here.
+
+**A concrete numeric lead worth flagging (hypothesis, not fact):**
+`body.max_diameter_m = 0.639 m` (Fusion bbox, currently unused by
+`load_geometry()`) is not read into Barrowman at all, but if it is meant to
+represent the fin-tip-to-fin-tip envelope diameter of the finned section,
+back-solving `d_ref + 2·span = 0.639` gives an implied span of
+`(0.639 − 0.250)/2 = 0.1945 m` — a **3.44x reduction** from the current
+0.6685 m. That factor falls almost exactly inside the 3.60x–4.80x band this
+sweep found necessary to reach a sane margin at Ma 2.5. This is a
+coincidence worth checking, not a confirmed root cause — Section 4, item 1,
+asks the team to check it directly against the CAD.
+
+## 4. Verification questions for the team (HUMAN_REVIEW — not resolved here)
+
+None of the following were acted on; no YAML value was changed. These are
+CAD-verification tasks against **Fusion Assembly v6**.
+
+1. **Fin-span vs. body bounding box.** Open Assembly v6 and directly measure
+   the fin-tip-to-fin-tip diameter of the aft stabilizer section. Compare
+   against `fins.span_m = 0.6685 m` (implying a tip-to-tip diameter of
+   `0.250 + 2×0.6685 = 1.6035 m`) versus `body.max_diameter_m = 0.639 m`
+   (Fusion bbox, currently unused by the stability code). These two numbers
+   describing the same vehicle differ by a factor of ~2.5x; determine which
+   one (if either) is the correct fin span, and specifically test the
+   `(0.639 − 0.250)/2 = 0.1945 m` hypothesis in Section 3.
+2. **Fin span vs. booster wing halfspan.** `fins.span_m = 0.6685 m`
+   (stabilizer, aft section) is suspiciously close in order of magnitude to
+   `stage_1.geometry.wings_halfspan_est_m = 0.780 m` (the *booster's*
+   PRD-240 control-fin halfspan, an already-flagged estimate). Confirm the
+   0.6685 m value in `fusion_extraction_v6.yaml` under
+   `fins.fin_properties.span_m` genuinely traces back to the
+   `stabilizer v11:1..4` bodies (aft ramjet section) in Assembly v6, and was
+   not accidentally sourced from the booster's own wing geometry during
+   extraction.
+3. **Units re-check, independent of the API script.** This extraction
+   pipeline already caught one cm/mm unit-conversion bug
+   (`fusion_extraction_v6.yaml` → `corrections.unit_system_fix`). Given that
+   history, manually read `fin_span_m` off the Assembly v6 sketch/parameter
+   panel in the Fusion GUI directly (not via the same API script that
+   produced the original bug) to independently confirm 0.6685 m rather than,
+   e.g., 66.85 mm or 6.685 cm misplaced by a decade.
+4. **Fin mounting position.** `barrowman_stability.py` assumes the fin root
+   trailing edge sits flush with the aft end of the rocket
+   (`fin_root_le_x_m = total_length_m − chord_root`). Confirm this against
+   the actual axial mounting position of the `stabilizer v11:*` bodies in
+   Assembly v6 — if the fins are mounted forward of the very aft tip, the
+   fin CP (and hence the whole-vehicle CP) shifts, independent of the span
+   question.
+5. **Nose→body transition length.** `TRANSITION_LENGTH_M = 0.10 m` is a
+   hardcoded code assumption, not present in either YAML file. Measure the
+   actual axial length of the 0.150 m → 0.250 m conical shoulder in Assembly
+   v6 and report it so it can be added as a real geometry field instead of
+   a guess.
+6. **Nose bluntness.** `fusion_extraction_v6.yaml` lists
+   `bluntness_radius_m: 0.0` for the nose cone (perfectly sharp tip).
+   Confirm this against the physical/CAD nose — a non-zero tip radius would
+   change the nose `CN_alpha`/CP formula, which currently assumes a pure
+   cone.
+7. **Teltik 2024 CFD geometry vintage.** Confirm what CAD revision Teltik
+   2024's CFD mesh was built from, and specifically whether its fin
+   geometry (span, chord, mounting) matches the *current* Assembly v6 or an
+   earlier iteration. If the fin span used in the CFD differs from 0.6685 m,
+   the Barrowman-vs-CFD comparison in `stability_margin_report.md` is not a
+   like-for-like comparison of the same vehicle, regardless of which
+   span value turns out to be correct.
+8. **Cross-Mach consistency of any corrected span.** Once a corrected
+   `fin_span_m` is confirmed, re-run the full Mach sweep (not just Ma 2.5)
+   to confirm the corrected value gives an acceptable static margin across
+   the whole flight envelope (boost, transonic, Ma 1.5, Ma 2.5 cruise) —
+   Section 3 showed the "reduction factor needed" is itself Mach-dependent,
+   so a value that fixes Ma 2.5 is not guaranteed to fix Ma 1.5 or M=0.
+9. **Moments of inertia, while the CAD is open.** Unrelated to CP but noted
+   here since it requires the same manual Assembly v6 GUI session:
+   `Ixx/Iyy/Izz` are still `"TBD"` in `fusion_extraction_v6.yaml` and
+   flagged in `doc/ramP/analysis_status.md` — worth extracting in the same
+   CAD pass as the fin-span check to avoid a second manual session.
+
+---
+
+**Verdict (unchanged from `stability_margin_report.md`):
+Prawdopodobny artefakt geometrii — wymaga przeglądu zespołu.** This
+reconciliation narrows the search: a ±20% span perturbation cannot explain
+the Barrowman-vs-CFD gap, but a ~3.6x–4.8x span reduction (Ma 2.5) can flip
+the sign back to positive and reach a healthy margin — and the
+`body.max_diameter_m = 0.639 m` bbox field, not currently used by the
+stability code at all, independently hints at a similar-order correction
+(~3.44x). None of this is confirmed; it is a set of concrete, numbered
+CAD-verification tasks for the team (Section 4), not a resolution.

--- a/tests/unit/test_cfd_su2_config.py
+++ b/tests/unit/test_cfd_su2_config.py
@@ -1,0 +1,104 @@
+# MELprop-IADE | tests.unit.test_cfd_su2_config | v0.1.0
+"""Smoke tests for analyses.cfd.su2_config_template.
+
+Only checks file-generation behaviour (one ``.cfg`` per Mach number,
+required geometry fields, the ``# TO RUN:`` hint) -- SU2 itself is never
+invoked, matching the module's file-generation-only contract.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from analyses.cfd.su2_config_template import (
+    MACH_SWEEP,
+    VEHICLE_CONFIG_PATH,
+    SU2ConfigGeneration,
+    load_rocket_config,
+    su2_config_filename,
+    write_mach_sweep_configs,
+)
+from core.component_base import FidelityLevel
+from src.schemas.vehicle_schema import RocketConfig
+
+
+@pytest.fixture()
+def rocket_config() -> RocketConfig:
+    """Load the committed ramjet-rocket configuration."""
+    return load_rocket_config(VEHICLE_CONFIG_PATH)
+
+
+def test_write_mach_sweep_configs_one_file_per_mach(
+    rocket_config: RocketConfig, tmp_path: Path
+) -> None:
+    """One .cfg file is written per Mach number in MACH_SWEEP."""
+    paths = write_mach_sweep_configs(rocket_config, output_dir=tmp_path)
+
+    assert len(paths) == len(MACH_SWEEP)
+    for mach, path in zip(MACH_SWEEP, paths):
+        assert path.name == su2_config_filename(mach)
+        assert path.exists()
+
+    written_files = sorted(tmp_path.glob("*.cfg"))
+    assert len(written_files) == len(MACH_SWEEP)
+
+
+def test_generated_config_has_geometry_and_run_hint(
+    rocket_config: RocketConfig, tmp_path: Path
+) -> None:
+    """Each config carries geometry pulled from the YAML plus the run hint."""
+    paths = write_mach_sweep_configs(rocket_config, output_dir=tmp_path)
+
+    d_ref = rocket_config.body.diameter_m
+    fin_span = rocket_config.fins.span_m
+
+    for path in paths:
+        text = path.read_text(encoding="utf-8")
+
+        # Required "how to run" hint for a human once SU2 is available.
+        assert f"# TO RUN: su2_CFD {path.name}" in text
+
+        # Geometry fields pulled from vehicle_config.yaml, not hard-coded.
+        assert f"{d_ref:.4f}" in text
+        assert f"{fin_span:.4f}" in text
+        assert "MESH_FILENAME=" in text
+        assert "REF_AREA=" in text
+        assert "REF_LENGTH=" in text
+
+        # Euler-only physics (no viscous / turbulence model keys).
+        assert "SOLVER= EULER" in text
+        assert "MACH_NUMBER=" in text
+
+
+def test_never_invokes_su2_binary(monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+                                   rocket_config: RocketConfig) -> None:
+    """Generation must not shell out to su2_CFD/gmsh (patch subprocess to fail loudly)."""
+    import subprocess
+
+    def _boom(*args: object, **kwargs: object) -> None:
+        raise AssertionError("su2_config_template must never invoke a subprocess")
+
+    monkeypatch.setattr(subprocess, "run", _boom)
+    monkeypatch.setattr(subprocess, "Popen", _boom)
+
+    paths = write_mach_sweep_configs(rocket_config, output_dir=tmp_path)
+    assert len(paths) == len(MACH_SWEEP)
+
+
+def test_su2_config_generation_analysis_execute(
+    rocket_config: RocketConfig, tmp_path: Path
+) -> None:
+    """SU2ConfigGeneration follows the BaseAnalysis setup/execute contract."""
+    analysis = SU2ConfigGeneration()
+    with pytest.raises(RuntimeError):
+        analysis.execute()
+
+    analysis.setup(rocket_config, output_dir=tmp_path)
+    results = analysis.execute()
+
+    assert results.fidelity == FidelityLevel.LEVEL_2
+    assert results["n_configs"] == len(MACH_SWEEP)
+    assert analysis.validate_results(results)
+    assert len(results.metadata["config_paths"]) == len(MACH_SWEEP)

--- a/tests/unit/test_missions_staged.py
+++ b/tests/unit/test_missions_staged.py
@@ -152,22 +152,127 @@ def _sample_burnout_state() -> BurnoutState:
     )
 
 
-def test_cruise_segment_has_positive_thrust_from_ramjet_cycle_model() -> None:
-    """The cruise segment's thrust_N comes from the L2 ramjet cycle model.
+def test_cruise_segment_has_positive_thrust_from_grzywka_cycle_model() -> None:
+    """The cruise segment's thrust_N comes from the L2 Grzywka cycle model.
 
     This asserts the design point is populated by
-    analyses.propulsion.ramjet_cycle.RamjetCycleAnalysis rather than the
-    old fixed-guess stub (thrust_N == 0.0 would indicate the fallback
-    stub path was taken).
+    analyses.propulsion.combustor_nozzle_cycle.GrzywkaCombustorNozzleAnalysis
+    rather than the old fixed-guess stub (thrust_N == 0.0 would indicate
+    the fallback stub path was taken), and that the top-level thrust_N
+    mirrors the nominal Th2 (real, combustor + nozzle losses) scenario.
     """
     mission = build_ramp_staged_mission(_sample_burnout_state())
     cruise_params = mission[2].parameters
 
     assert cruise_params["thrust_N"] > 0.0
-    assert cruise_params["thrust_cylindrical_nozzle_N"] > 0.0
-    # CAD cylindrical (unexpanded) nozzle must produce less thrust than
-    # the matched design nozzle (per ramjet_cycle validate_results()).
-    assert cruise_params["thrust_cylindrical_nozzle_N"] < cruise_params["thrust_N"]
+    scenarios = cruise_params["thrust_scenarios"]
+    assert cruise_params["thrust_N"] == pytest.approx(scenarios["Th2"]["thrust_N"])
+
+
+def test_cruise_segment_preserves_all_three_grzywka_thrust_scenarios() -> None:
+    """Thi/Th1/Th2 are all preserved as separate named scenarios, never collapsed.
+
+    Per Grzywka Sec. 6.2.2, the physical hierarchy Thi >= Th1 >= Th2 must
+    hold since the three scenarios share identical mass flow, Tt1, Tt2
+    and fuel-air ratio -- only the delivered nozzle total pressure
+    differs (see analyses.propulsion.combustor_nozzle_cycle module
+    docstring).
+    """
+    mission = build_ramp_staged_mission(_sample_burnout_state())
+    cruise_params = mission[2].parameters
+
+    assert "thrust_scenarios" in cruise_params
+    scenarios = cruise_params["thrust_scenarios"]
+    assert set(scenarios.keys()) == {"Thi", "Th1", "Th2"}
+
+    thi, th1, th2 = (
+        scenarios["Thi"]["thrust_N"],
+        scenarios["Th1"]["thrust_N"],
+        scenarios["Th2"]["thrust_N"],
+    )
+    assert thi > 0.0 and th1 > 0.0 and th2 > 0.0
+    assert thi >= th1 >= th2
+
+
+def test_cruise_segment_scenario_dicts_have_expected_fields() -> None:
+    """Each thrust scenario carries its own TSFC, Isp, cruise time and range."""
+    mission = build_ramp_staged_mission(_sample_burnout_state())
+    scenarios = mission[2].parameters["thrust_scenarios"]
+
+    for key in ("Thi", "Th1", "Th2"):
+        scenario = scenarios[key]
+        for field in (
+            "thrust_N",
+            "tsfc_kg_per_Ns",
+            "isp_s",
+            "mdot_fuel_kg_s",
+            "cruise_time_s",
+            "cruise_range_m",
+            "description",
+        ):
+            assert field in scenario, f"scenario {key!r} missing {field!r}"
+        assert scenario["thrust_N"] > 0.0
+        assert scenario["tsfc_kg_per_Ns"] > 0.0
+        assert scenario["isp_s"] > 0.0
+        assert scenario["mdot_fuel_kg_s"] > 0.0
+        assert math.isfinite(scenario["cruise_time_s"])
+        assert scenario["cruise_time_s"] > 0.0
+        assert math.isfinite(scenario["cruise_range_m"])
+        assert scenario["cruise_range_m"] > 0.0
+
+
+def test_cruise_segment_scenario_fuel_flow_is_invariant_across_thrust_models() -> None:
+    """mdot_fuel_kg_s is identical across Thi/Th1/Th2 (Grzywka model property).
+
+    The three thrust scenarios share the same combustor mass flow, Tt1,
+    Tt2 and fuel-air ratio; only the delivered nozzle total pressure
+    differs. tsfc_kg_per_Ns and isp_s, however, DO vary with thrust:
+    higher thrust (Thi) means lower TSFC and higher Isp than the more
+    conservative Th2.
+    """
+    mission = build_ramp_staged_mission(_sample_burnout_state())
+    scenarios = mission[2].parameters["thrust_scenarios"]
+
+    mdot_thi = scenarios["Thi"]["mdot_fuel_kg_s"]
+    mdot_th1 = scenarios["Th1"]["mdot_fuel_kg_s"]
+    mdot_th2 = scenarios["Th2"]["mdot_fuel_kg_s"]
+    assert mdot_thi == pytest.approx(mdot_th1)
+    assert mdot_th1 == pytest.approx(mdot_th2)
+
+    # Higher thrust -> lower TSFC, higher Isp (same fuel flow, more thrust
+    # per unit fuel).
+    assert scenarios["Thi"]["tsfc_kg_per_Ns"] <= scenarios["Th2"]["tsfc_kg_per_Ns"]
+    assert scenarios["Thi"]["isp_s"] >= scenarios["Th2"]["isp_s"]
+
+
+def test_cruise_segment_scenario_range_and_endurance_computed_per_scenario() -> None:
+    """cruise_time_s/cruise_range_m are derived per-scenario, not copy-pasted from Th2.
+
+    Because mdot_fuel_kg_s is scenario-invariant (see
+    test_cruise_segment_scenario_fuel_flow_is_invariant_across_thrust_models),
+    cruise_time_s and cruise_range_m come out numerically equal across
+    the three scenarios at this constant-cruise-Mach design point -- a
+    documented physical property of the Grzywka model, not a shortcut
+    that reused Th2's number without deriving it per scenario. Each
+    scenario's own cruise_time_s must still be internally consistent
+    with ITS OWN fuel_mass_kg / mdot_fuel_kg_s.
+    """
+    mission = build_ramp_staged_mission(_sample_burnout_state())
+    cruise_params = mission[2].parameters
+    scenarios = cruise_params["thrust_scenarios"]
+    fuel_mass_kg = cruise_params["fuel_mass_kg"]
+
+    for key in ("Thi", "Th1", "Th2"):
+        scenario = scenarios[key]
+        expected_time_s = fuel_mass_kg / scenario["mdot_fuel_kg_s"]
+        assert scenario["cruise_time_s"] == pytest.approx(expected_time_s, rel=1e-6)
+
+    assert scenarios["Thi"]["cruise_time_s"] == pytest.approx(
+        scenarios["Th2"]["cruise_time_s"]
+    )
+    assert scenarios["Thi"]["cruise_range_m"] == pytest.approx(
+        scenarios["Th2"]["cruise_range_m"]
+    )
 
 
 def test_cruise_segment_tsfc_in_plausible_hydrocarbon_ramjet_band() -> None:

--- a/tests/unit/test_propulsion_combustor_nozzle.py
+++ b/tests/unit/test_propulsion_combustor_nozzle.py
@@ -1,0 +1,238 @@
+# MELprop-IADE | tests.unit.test_propulsion_combustor_nozzle | v0.1.0
+"""Unit tests for analyses.propulsion.combustor_nozzle_cycle (Grzywka)."""
+
+import math
+
+import pytest
+
+from analyses.propulsion.combustor_nozzle_cycle import (
+    COMBUSTOR_EXIT_TEMP_DEFAULT_K,
+    PI_CC,
+    PI_NOZZLE,
+    TELTIK_ALTITUDE_M,
+    TELTIK_MACH,
+    TELTIK_V3_M_S,
+    GrzywkaCombustorNozzleAnalysis,
+    brayton_t2_estimate_K,
+    choked_throat_area_m2,
+    fully_expanded_exit,
+)
+from analyses.propulsion.inlet_performance import DESIGN_ALTITUDE_M, MACH_DESIGN
+from analyses.propulsion.ramjet_cycle import (
+    CP_HOT,
+    GAMMA_HOT,
+    R_HOT,
+    RamjetCycleAnalysis,
+)
+from core.component_base import AnalysisResults, FidelityLevel
+
+
+# --------------------------------------------------------------------------
+# Component-level function tests
+# --------------------------------------------------------------------------
+
+
+def test_grzywka_loss_coefficients_match_assumptions_a13() -> None:
+    """pi_CC / pi_nozzle are the documented Grzywka 2022 values (A13)."""
+    assert PI_CC == pytest.approx(0.8924)
+    assert PI_NOZZLE == pytest.approx(0.97)
+
+
+def test_choked_throat_is_sonic_and_dynamic() -> None:
+    """Throat is choked (Ma=1) and its area scales with mass flow."""
+    low = choked_throat_area_m2(10.0, 2000.0, 3.5e5, GAMMA_HOT, R_HOT)
+    high = choked_throat_area_m2(20.0, 2000.0, 3.5e5, GAMMA_HOT, R_HOT)
+    assert low["Ma21"] == pytest.approx(1.0)
+    # Sonic throat: u21 must equal the local speed of sound.
+    a21 = math.sqrt(GAMMA_HOT * R_HOT * low["T21_K"])
+    assert low["u21_m_s"] == pytest.approx(a21, rel=1e-9)
+    # Dynamic area: doubling mdot doubles the required throat area.
+    assert high["A21_m2"] == pytest.approx(2.0 * low["A21_m2"], rel=1e-9)
+    assert high["A21_m2"] > low["A21_m2"]
+
+
+def test_choked_throat_area_from_continuity_hand_calc() -> None:
+    """A21 = mdot / (rho21 * a21) reproduced independently."""
+    mdot, tt2, pt2 = 15.85, 2000.0, 3.52e5
+    res = choked_throat_area_m2(mdot, tt2, pt2, GAMMA_HOT, R_HOT)
+    cr = 2.0 / (GAMMA_HOT + 1.0)
+    t21 = tt2 * cr
+    p21 = pt2 * cr ** (GAMMA_HOT / (GAMMA_HOT - 1.0))
+    a21 = math.sqrt(GAMMA_HOT * R_HOT * t21)
+    rho21 = p21 / (R_HOT * t21)
+    assert res["A21_m2"] == pytest.approx(mdot / (rho21 * a21), rel=1e-9)
+
+
+def test_lower_nozzle_total_pressure_gives_lower_exit_velocity() -> None:
+    """A larger total-pressure loss must reduce the fully-expanded V3."""
+    ideal = fully_expanded_exit(2000.0, 4.0e5, 2.6e4, 15.85, GAMMA_HOT, CP_HOT, R_HOT)
+    lossy = fully_expanded_exit(2000.0, 3.0e5, 2.6e4, 15.85, GAMMA_HOT, CP_HOT, R_HOT)
+    assert lossy["V3_m_s"] < ideal["V3_m_s"]
+    assert ideal["p3_Pa"] == pytest.approx(2.6e4)  # fully expanded to p0
+
+
+def test_brayton_estimate_increases_with_fuel_air_ratio() -> None:
+    """More fuel -> higher Brayton combustor-exit temperature."""
+    low = brayton_t2_estimate_K(500.0, 0.03, 0.95, 43.1e6, 1004.5)
+    high = brayton_t2_estimate_K(500.0, 0.05, 0.95, 43.1e6, 1004.5)
+    assert high > low > 500.0
+
+
+# --------------------------------------------------------------------------
+# Analysis-level tests
+# --------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def design_results() -> AnalysisResults:
+    """Design-point (Mach 2.5 / 10 km) Grzywka cycle results."""
+    analysis = GrzywkaCombustorNozzleAnalysis()
+    analysis.setup(mach0=MACH_DESIGN, altitude_m=DESIGN_ALTITUDE_M)
+    return analysis.execute()
+
+
+def test_fidelity_is_level_2(design_results: AnalysisResults) -> None:
+    assert design_results.fidelity is FidelityLevel.LEVEL_2
+
+
+def test_three_thrust_models_all_reported(design_results: AnalysisResults) -> None:
+    """All three thrust models are present and positive."""
+    for key in ("Thi_N", "Th1_N", "Th2_N"):
+        assert key in design_results
+        assert design_results[key] > 0.0
+
+
+def test_thrust_hierarchy_thi_ge_th1_ge_th2(design_results: AnalysisResults) -> None:
+    """MANDATORY physical hierarchy: Thi >= Th1 >= Th2."""
+    thi = design_results["Thi_N"]
+    th1 = design_results["Th1_N"]
+    th2 = design_results["Th2_N"]
+    assert thi >= th1 >= th2
+    # Losses must actually cost thrust (strict, not merely equal).
+    assert thi > th1 > th2
+
+
+def test_th2_is_the_nominal_thrust(design_results: AnalysisResults) -> None:
+    """The exposed nominal thrust must be the conservative Th2."""
+    assert design_results["thrust_nominal_N"] == pytest.approx(
+        design_results["Th2_N"]
+    )
+
+
+def test_throat_is_choked_and_dynamic(design_results: AnalysisResults) -> None:
+    """Station 21 is sonic and its area is a positive solved quantity."""
+    assert design_results["Ma21"] == pytest.approx(1.0)
+    assert design_results["A21_throat_m2"] > 0.0
+    assert design_results["D21_throat_m"] > 0.0
+
+
+def test_throat_area_tracks_flight_condition() -> None:
+    """Dynamic throat: a different (V, H) yields a different A21."""
+    design = GrzywkaCombustorNozzleAnalysis()
+    design.setup(mach0=2.5, altitude_m=10_000.0)
+    a_design = design.execute()["A21_throat_m2"]
+
+    other = GrzywkaCombustorNozzleAnalysis()
+    other.setup(mach0=2.5, altitude_m=6_000.0)
+    a_other = other.execute()["A21_throat_m2"]
+
+    # The throat is solved from continuity at each (V, H): a different
+    # altitude must change A21 (it is NOT a hard-coded constant). Both
+    # mdot and the sonic throat density scale with the flight condition,
+    # so only the fact that A21 moves is asserted, not its direction.
+    assert a_other != pytest.approx(a_design, rel=1e-3)
+    assert a_design > 0.0 and a_other > 0.0
+
+
+def test_thi_within_15pct_of_ramjet_cycle_design_thrust(
+    design_results: AnalysisResults,
+) -> None:
+    """Ideal/matched thrust within 15% of ramjet_cycle at the same point."""
+    ramjet = RamjetCycleAnalysis()
+    ramjet.setup(mach0=MACH_DESIGN, altitude_m=DESIGN_ALTITUDE_M)
+    ramjet_thrust_N = ramjet.execute()["thrust_N"]
+
+    # Th1 (fully expanded + combustor loss) is the closest apples-to-apples
+    # match to ramjet_cycle's matched-nozzle-with-pi_b thrust; Thi (ideal)
+    # is the loss-free bound. Both must sit within 15%.
+    for key in ("Thi_N", "Th1_N"):
+        delta = abs(design_results[key] - ramjet_thrust_N) / ramjet_thrust_N
+        assert delta < 0.15, f"{key} delta {delta:.3f} exceeds 15%"
+
+
+def test_brayton_t2_cross_check_logged(design_results: AnalysisResults) -> None:
+    """The Brayton T2 delta is quantified and flagged in metadata."""
+    b = design_results.metadata["brayton_t2_cross_check"]
+    assert b["station_model_tt2_K"] == pytest.approx(COMBUSTOR_EXIT_TEMP_DEFAULT_K)
+    assert b["brayton_estimate_tt2_K"] > 0.0
+    assert "delta_frac" in b
+    assert isinstance(b["exceeds_5pct"], bool)
+
+
+def test_teltik_v3_cross_check_logged(design_results: AnalysisResults) -> None:
+    """V3-vs-Teltik delta evaluated at the CFD reference condition."""
+    t = design_results.metadata["teltik_v3_cross_check"]
+    assert t["teltik_cfd_v3_m_s"] == pytest.approx(TELTIK_V3_M_S)
+    assert f"{TELTIK_MACH}" in t["condition"]
+    assert f"{TELTIK_ALTITUDE_M:.0f}" in t["condition"]
+    assert t["model_v3_m_s"] > 0.0
+
+
+def test_nozzle_area_ratio_reports_all_three(
+    design_results: AnalysisResults,
+) -> None:
+    """Model / YAML-design / CAD area ratios are all surfaced."""
+    assert design_results["nozzle_area_ratio_model"] > 0.0
+    assert design_results["nozzle_area_ratio_design_yaml"] == pytest.approx(4.0)
+    assert design_results["nozzle_area_ratio_cad_cylindrical"] == pytest.approx(1.0)
+
+
+def test_isp_in_hydrocarbon_ramjet_band(design_results: AnalysisResults) -> None:
+    assert 400.0 < design_results["isp_s"] < 3000.0
+
+
+def test_fuel_air_ratio_physical(design_results: AnalysisResults) -> None:
+    assert 0.0 < design_results["f_fuel_air"] < 0.15
+
+
+# --------------------------------------------------------------------------
+# Guard / validation tests
+# --------------------------------------------------------------------------
+
+
+def test_execute_before_setup_raises() -> None:
+    with pytest.raises(RuntimeError):
+        GrzywkaCombustorNozzleAnalysis().execute()
+
+
+def test_setup_rejects_subsonic_mach() -> None:
+    with pytest.raises(ValueError):
+        GrzywkaCombustorNozzleAnalysis().setup(mach0=0.8, altitude_m=10_000.0)
+
+
+def test_setup_rejects_out_of_range_loss_coefficient() -> None:
+    with pytest.raises(ValueError):
+        GrzywkaCombustorNozzleAnalysis().setup(mach0=2.5, pi_cc=1.5)
+
+
+def test_setup_rejects_combustor_temp_below_inlet_total() -> None:
+    """Tt2 must exceed the recovered inlet total temperature."""
+    with pytest.raises(ValueError):
+        GrzywkaCombustorNozzleAnalysis().setup(
+            mach0=2.5, altitude_m=10_000.0, combustor_exit_temp_K=300.0
+        )
+
+
+def test_validate_results_rejects_broken_hierarchy(
+    design_results: AnalysisResults,
+) -> None:
+    """A hierarchy violation (Th2 > Th1) must fail validation."""
+    analysis = GrzywkaCombustorNozzleAnalysis()
+    analysis.setup(mach0=MACH_DESIGN, altitude_m=DESIGN_ALTITUDE_M)
+    bad = AnalysisResults(
+        name="bad",
+        fidelity=FidelityLevel.LEVEL_2,
+        data=dict(design_results.data),
+    )
+    bad.data["Th2_N"] = bad.data["Th1_N"] + 1.0  # break the hierarchy
+    assert analysis.validate_results(bad) is False

--- a/tests/unit/test_propulsion_inlet.py
+++ b/tests/unit/test_propulsion_inlet.py
@@ -6,13 +6,17 @@ import math
 import pytest
 
 from analyses.propulsion.inlet_performance import (
+    DEFAULT_INLET_ACTUATION,
     DEFAULT_N_CONES_M25,
     ETA_DIFFUSER,
     GAMMA,
+    MACH_SPIKE_DESIGN,
     MULTI_CONE_THETA_DEG_4CONE,
     MULTI_CONE_THETA_DEG_5CONE,
     InletPerformanceAnalysis,
+    MovableInletActuation,
     MultiConeInletPerformanceAnalysis,
+    compute_transition_sequence,
     isa_atmosphere,
     mil_e_5007_eta_std,
     multi_cone_recovery_chain,
@@ -234,6 +238,121 @@ def test_multi_cone_inlet_analysis_setup_rejects_bad_inputs() -> None:
         analysis.setup(n_cones=0)
     with pytest.raises(ValueError):
         analysis.setup(eta_diffuser=0.0)
+
+
+# ---------------------------------------------------------------------------
+# Movable (translating-centerbody) spike inlet — actuation model (Phase 4b)
+# ---------------------------------------------------------------------------
+
+
+def test_movable_inlet_actuation_todo_physical_params_are_flagged() -> None:
+    """All four actuation fields are TODO_PHYSICAL_PARAM placeholders — assert
+    they are clearly flagged with a documented range in metadata (we have no
+    ground truth for their magnitudes, only that they must be marked)."""
+    meta = DEFAULT_INLET_ACTUATION.metadata()
+    todo = meta["todo_physical_params"]
+    for field in (
+        "screw_lead_mm",
+        "motor_torque_Nm",
+        "cone_travel_mm",
+        "transition_time_s",
+    ):
+        assert field in todo
+        assert todo[field].startswith("TODO_PHYSICAL_PARAM")
+        assert "typical" in todo[field]
+        # The field is still present with a (placeholder) numeric value.
+        assert isinstance(meta[field], float)
+    assert "No Grzywka MATLAB actuator data" in meta["source"]
+
+
+def test_movable_inlet_actuation_defaults_within_documented_ranges() -> None:
+    """Placeholder defaults sit inside the documented typical ranges (this
+    checks the defaults are self-consistent, NOT that they are 'correct')."""
+    a = DEFAULT_INLET_ACTUATION
+    assert 1.0 <= a.screw_lead_mm <= 10.0
+    assert 0.1 <= a.motor_torque_Nm <= 2.0
+    assert 30.0 <= a.cone_travel_mm <= 90.0
+    assert 1.0 <= a.transition_time_s <= 10.0
+    assert a.slew_rate_mm_s == pytest.approx(
+        a.cone_travel_mm / a.transition_time_s
+    )
+
+
+def test_cone_position_for_mach_endpoints_and_clamp() -> None:
+    """Position schedule pins 0 mm at retracted Mach and full stroke at design
+    Mach, and clamps above the design Mach."""
+    a = MovableInletActuation()
+    assert a.cone_position_for_mach(0.0) == pytest.approx(0.0)
+    assert a.cone_position_for_mach(MACH_SPIKE_DESIGN) == pytest.approx(
+        a.cone_travel_mm
+    )
+    # Beyond the design Mach the stroke is clamped, not extrapolated.
+    assert a.cone_position_for_mach(3.5) == pytest.approx(a.cone_travel_mm)
+
+
+def test_transition_sequence_startup_m0_to_m25() -> None:
+    """Startup/acceleration M0 -> M2.5: monotonically INCREASING position from
+    0 mm to full stroke, starting at t=0 and ending at the full-stroke time."""
+    a = MovableInletActuation()
+    seq = compute_transition_sequence(0.0, 2.5, velocity_m_s=0.0, altitude_m=0.0)
+
+    times = [t for t, _ in seq]
+    positions = [p for _, p in seq]
+
+    # Correct start/end times.
+    assert times[0] == pytest.approx(0.0)
+    assert times[-1] == pytest.approx(a.transition_time_s)  # full stroke
+    # Correct start/end positions.
+    assert positions[0] == pytest.approx(0.0)
+    assert positions[-1] == pytest.approx(a.cone_travel_mm)
+    # Monotonic (non-decreasing) position and strictly increasing time.
+    assert all(p2 >= p1 for p1, p2 in zip(positions, positions[1:]))
+    assert all(t2 > t1 for t1, t2 in zip(times, times[1:]))
+    # Every sampled position stays within the stroke limits.
+    assert all(0.0 <= p <= a.cone_travel_mm + 1e-9 for p in positions)
+
+
+def test_transition_sequence_shutdown_m25_to_m0() -> None:
+    """Shutdown/deceleration M2.5 -> M0: monotonically DECREASING position from
+    full stroke back to 0 mm, over the same full-stroke duration."""
+    a = MovableInletActuation()
+    seq = compute_transition_sequence(2.5, 0.0, velocity_m_s=740.0, altitude_m=10_000.0)
+
+    times = [t for t, _ in seq]
+    positions = [p for _, p in seq]
+
+    assert times[0] == pytest.approx(0.0)
+    assert times[-1] == pytest.approx(a.transition_time_s)
+    assert positions[0] == pytest.approx(a.cone_travel_mm)
+    assert positions[-1] == pytest.approx(0.0)
+    # Monotonic (non-increasing) position.
+    assert all(p2 <= p1 for p1, p2 in zip(positions, positions[1:]))
+    assert all(0.0 <= p <= a.cone_travel_mm + 1e-9 for p in positions)
+
+
+def test_transition_sequence_zero_move_returns_single_sample() -> None:
+    """A no-op transition (identical Mach) returns one (0.0, position) point."""
+    seq = compute_transition_sequence(2.5, 2.5, velocity_m_s=740.0, altitude_m=10_000.0)
+    assert len(seq) == 1
+    assert seq[0][0] == pytest.approx(0.0)
+    assert seq[0][1] == pytest.approx(DEFAULT_INLET_ACTUATION.cone_travel_mm)
+
+
+def test_transition_sequence_partial_move_duration_scales_with_delta() -> None:
+    """A half-stroke move (M0 -> M1.25) takes half the full-stroke time."""
+    a = MovableInletActuation()
+    seq = compute_transition_sequence(
+        0.0, MACH_SPIKE_DESIGN / 2.0, velocity_m_s=370.0, altitude_m=5000.0
+    )
+    assert seq[-1][0] == pytest.approx(a.transition_time_s / 2.0)
+    assert seq[-1][1] == pytest.approx(a.cone_travel_mm / 2.0)
+
+
+def test_transition_sequence_rejects_bad_inputs() -> None:
+    with pytest.raises(ValueError):
+        compute_transition_sequence(0.0, 2.5, 0.0, 0.0, n_samples=1)
+    with pytest.raises(ValueError):
+        compute_transition_sequence(-0.5, 2.5, 0.0, 0.0)
 
 
 def test_inlet_performance_analysis_mass_flow_scales_with_capture_area() -> None:

--- a/workflows/ramp_staged_mission.py
+++ b/workflows/ramp_staged_mission.py
@@ -7,11 +7,26 @@ segments from solid-booster ignition through ramjet cruise. The mission
 includes a staging event that propagates the booster burnout state (mass,
 velocity, altitude) as initial conditions for the ramjet cruise segment.
 
+The ramjet-cruise design point (segment 3, ``cruise_stage_2_ramjet``) is
+computed from
+:class:`analyses.propulsion.combustor_nozzle_cycle.GrzywkaCombustorNozzleAnalysis`
+(the Grzywka station 1-2-21-3 combustor/nozzle cycle). Its three thrust
+scenarios -- ``Thi`` (ideal), ``Th1`` (combustor loss only) and ``Th2``
+(real, combustor + nozzle losses) -- are never collapsed to a single
+number: each is propagated through its own cruise-time/range derivation
+and preserved under the cruise segment's ``thrust_scenarios`` parameter,
+with ``Th2`` (most conservative) also mirrored at the top level as the
+mission's nominal design point.
+
 Theory / model references:
     - Staging dynamics: Sutton & Biblarz, *Rocket Propulsion Elements*, ch. 4
       (stage separation, momentum balance, coast phase).
     - Mission segment sequencing: SUAVE mission structure, adapted to a
       solver-agnostic builder pattern per CLAUDE.md architecture.
+    - Ramjet cruise cycle: Grzywka, *Analiza numeryczna komory spalania i
+      dyszy silnika strumieniowego*, Politechnika Warszawska, 2022, Sec.
+      6.2.2 (three-thrust decomposition), via
+      :mod:`analyses.propulsion.combustor_nozzle_cycle`.
 
 Run as a script to print the mission profile and booster-burnout handoff state::
 
@@ -152,13 +167,19 @@ def build_ramp_staged_mission(burnout_state: BurnoutState) -> list[MissionSegmen
     )
 
     # Segment 3: Ramjet cruise (stage-2) — quasi-steady design point.
-    # Thrust/TSFC/mdot_fuel are computed from the L2 1-D ramjet cycle model
-    # (analyses.propulsion.ramjet_cycle.RamjetCycleAnalysis) at the design
-    # condition (Mach 2.5, 10,000 m ISA). This is still NOT a trajectory
-    # ODE integration (fuel depletion, drag, and altitude/velocity coupling
-    # over time remain TBD); it is a single quasi-steady operating point
-    # used to derive a first-order cruise_time_s / cruise_range_m estimate
-    # from the SZACOWANY 15 kg fuel load.
+    # Thrust/TSFC/Isp/mdot_fuel are computed from the L2 1-D Grzywka
+    # combustor+nozzle cycle model
+    # (analyses.propulsion.combustor_nozzle_cycle.GrzywkaCombustorNozzleAnalysis)
+    # at the design condition (Mach 2.5, 10,000 m ISA), for EACH of the
+    # three Grzywka thrust scenarios (Thi ideal / Th1 combustor-loss-only /
+    # Th2 real — see _THRUST_SCENARIOS below); Th2 (most conservative) is
+    # the nominal top-level design point, but all three are preserved
+    # under cruise_design_point["thrust_scenarios"]. This is still NOT a
+    # trajectory ODE integration (fuel depletion, drag, and
+    # altitude/velocity coupling over time remain TBD); it is a single
+    # quasi-steady operating point used to derive a first-order
+    # cruise_time_s / cruise_range_m estimate PER SCENARIO from the
+    # SZACOWANY 15 kg fuel load.
     cruise_design_point = _compute_ramjet_design_point()
 
     builder.add_segment(
@@ -171,10 +192,23 @@ def build_ramp_staged_mission(burnout_state: BurnoutState) -> list[MissionSegmen
     return builder.build()
 
 
-#: Fallback cruise-segment parameters used only if the L2 ramjet cycle
-#: model (analyses.propulsion.ramjet_cycle) is unavailable or raises an
-#: unexpected error. These reproduce the original fixed-guess stub so the
-#: mission structure keeps degrading gracefully rather than failing.
+#: Grzywka three-thrust-model scenarios (Sec. 6.2.2), in canonical order
+#: from least to most conservative. Each tuple is
+#: ``(scenario_key, results_data_key, description)``; ``results_data_key``
+#: indexes the ``AnalysisResults`` returned by
+#: :meth:`analyses.propulsion.combustor_nozzle_cycle.GrzywkaCombustorNozzleAnalysis.execute`.
+_THRUST_SCENARIOS: tuple[tuple[str, str, str], ...] = (
+    ("Thi", "Thi_N", "ideal: no combustor or nozzle total-pressure losses (upper bound)"),
+    ("Th1", "Th1_N", "combustor total-pressure loss only, nozzle idealized"),
+    ("Th2", "Th2_N", "real: combustor AND nozzle total-pressure losses (nominal)"),
+)
+
+
+#: Fallback cruise-segment parameters used only if the L2 combustor/nozzle
+#: cycle model (analyses.propulsion.combustor_nozzle_cycle) is unavailable
+#: or raises an unexpected error. These reproduce the original fixed-guess
+#: stub, extended with a ``thrust_scenarios`` block so downstream code that
+#: expects all three Grzywka scenarios keeps working even in degraded mode.
 _STUB_CRUISE_DESIGN_POINT: dict[str, Any] = {
     "design_mach": 2.5,  # from vehicle_config.yaml stage_2.design_mach
     "cruise_altitude_m": 10000.0,  # TBD — design decision, typical ramjet cruise alt
@@ -182,27 +216,99 @@ _STUB_CRUISE_DESIGN_POINT: dict[str, Any] = {
     "cruise_range_m": 0.0,  # TBD — cannot be derived without the cycle model
     "fuel_mass_kg": 15.0,  # SZACOWANY — placeholder stage-2 fuel load
     "thrust_N": 0.0,  # TBD — cycle model unavailable
-    "thrust_cylindrical_nozzle_N": 0.0,  # TBD — cycle model unavailable
     "tsfc_kg_per_Ns": 0.0,  # TBD — cycle model unavailable
+    "isp_s": 0.0,  # TBD — cycle model unavailable
     "mdot_fuel_kg_s": 0.0,  # TBD — cycle model unavailable
+    "thrust_scenarios": {
+        key: {
+            "thrust_N": 0.0,
+            "tsfc_kg_per_Ns": 0.0,
+            "isp_s": 0.0,
+            "mdot_fuel_kg_s": 0.0,
+            "cruise_time_s": 60.0,
+            "cruise_range_m": 0.0,
+            "description": description,
+        }
+        for key, _field, description in _THRUST_SCENARIOS
+    },
     "note": (
-        "FALLBACK STUB: analyses.propulsion.ramjet_cycle raised an "
-        "unexpected error, so this segment reverted to fixed-guess "
-        "placeholder values (thrust/TSFC/mdot_fuel = 0.0, cruise_time_s = "
-        "60.0 s placeholder). Re-run once the ramjet cycle model is "
-        "fixed to recover a real design point."
+        "FALLBACK STUB: analyses.propulsion.combustor_nozzle_cycle raised "
+        "an unexpected error, so this segment reverted to fixed-guess "
+        "placeholder values (thrust/TSFC/mdot_fuel = 0.0 for all three "
+        "Thi/Th1/Th2 scenarios, cruise_time_s = 60.0 s placeholder). "
+        "Re-run once the Grzywka combustor/nozzle cycle model is fixed to "
+        "recover a real design point."
     ),
 }
 
 
-def _compute_ramjet_design_point() -> dict[str, Any]:
-    """Compute the stage-2 ramjet cruise design point via the L2 cycle model.
+def _scenario_cruise_point(
+    thrust_N: float,
+    mdot_fuel_kg_s: float,
+    fuel_mass_kg: float,
+    v_cruise_ms: float,
+    g0_m_s2: float,
+) -> dict[str, float]:
+    """Derive TSFC, Isp, cruise time and range for one thrust scenario.
 
-    Runs :class:`analyses.propulsion.ramjet_cycle.RamjetCycleAnalysis` at
-    the design condition (Mach 2.5, 10,000 m ISA) and derives a first-order
-    quasi-steady cruise duration and range from the SZACOWANY 15 kg fuel
-    load: ``cruise_time_s = fuel_mass_kg / mdot_fuel_kg_s`` and
-    ``cruise_range_m = V_cruise * cruise_time_s``.
+    Fuel flow ``mdot_fuel_kg_s`` is, by construction of the Grzywka
+    station model, IDENTICAL across the Thi/Th1/Th2 thrust scenarios (same
+    mass flow, Tt1, Tt2 and fuel-air ratio; only the delivered nozzle
+    total pressure differs — see the
+    :mod:`analyses.propulsion.combustor_nozzle_cycle` module docstring).
+    Consequently ``cruise_time_s = fuel_mass_kg / mdot_fuel_kg_s`` and
+    ``cruise_range_m = V_cruise * cruise_time_s`` come out numerically
+    equal across scenarios at THIS quasi-steady, constant-cruise-Mach
+    design point (thrust differences show up in ``tsfc_kg_per_Ns`` /
+    ``isp_s``, not in burn duration, since the combustor sets fuel flow
+    independent of nozzle loss). This coincidence is a physical property
+    of the model and is surfaced explicitly here rather than hidden, per
+    this repo's method-discrepancy convention; a future trajectory-ODE
+    cruise model (fuel depletion + drag/altitude/velocity coupling) would
+    let a lower-thrust scenario diverge from the assumed constant Mach.
+
+    Args:
+        thrust_N: Scenario thrust [N] (Thi, Th1 or Th2).
+        mdot_fuel_kg_s: Fuel mass flow [kg/s] (scenario-invariant).
+        fuel_mass_kg: Available stage-2 fuel mass [kg].
+        v_cruise_ms: Cruise (freestream) velocity [m/s].
+        g0_m_s2: Standard gravity used for the Isp definition [m/s^2].
+
+    Returns:
+        Dict with ``thrust_N``, ``tsfc_kg_per_Ns``, ``isp_s``,
+        ``mdot_fuel_kg_s``, ``cruise_time_s`` and ``cruise_range_m``.
+    """
+    tsfc_kg_per_Ns = mdot_fuel_kg_s / thrust_N
+    isp_s = thrust_N / (mdot_fuel_kg_s * g0_m_s2)
+    cruise_time_s = fuel_mass_kg / mdot_fuel_kg_s
+    cruise_range_m = v_cruise_ms * cruise_time_s
+    return {
+        "thrust_N": thrust_N,
+        "tsfc_kg_per_Ns": tsfc_kg_per_Ns,
+        "isp_s": isp_s,
+        "mdot_fuel_kg_s": mdot_fuel_kg_s,
+        "cruise_time_s": cruise_time_s,
+        "cruise_range_m": cruise_range_m,
+    }
+
+
+def _compute_ramjet_design_point() -> dict[str, Any]:
+    """Compute the stage-2 ramjet cruise design point via the L2 Grzywka cycle.
+
+    Runs
+    :class:`analyses.propulsion.combustor_nozzle_cycle.GrzywkaCombustorNozzleAnalysis`
+    at the design condition (Mach 2.5, 10,000 m ISA) and derives, for
+    EACH of the three Grzywka thrust scenarios (``Thi`` ideal, ``Th1``
+    combustor-loss-only, ``Th2`` real/combustor+nozzle losses — see
+    :data:`_THRUST_SCENARIOS`), a first-order quasi-steady cruise duration
+    and range from the SZACOWANY 15 kg fuel load via
+    :func:`_scenario_cruise_point`. The three scenarios are never
+    collapsed to a single number: all three are returned under
+    ``thrust_scenarios``, keyed ``"Thi"``/``"Th1"``/``"Th2"``. The
+    top-level ``thrust_N``/``tsfc_kg_per_Ns``/``isp_s``/``cruise_time_s``/
+    ``cruise_range_m`` fields mirror the ``Th2`` (real, most conservative)
+    scenario, since that is the nominal design point for the rest of the
+    mission profile.
 
     This is a design-point evaluation, NOT a trajectory ODE — fuel
     depletion, drag and altitude/velocity coupling over time are not
@@ -218,51 +324,73 @@ def _compute_ramjet_design_point() -> dict[str, Any]:
     fuel_mass_kg = 15.0  # SZACOWANY — placeholder stage-2 fuel load
 
     try:
-        from analyses.propulsion.ramjet_cycle import (
+        from analyses.propulsion.combustor_nozzle_cycle import (
+            GrzywkaCombustorNozzleAnalysis,
+        )
+        from analyses.propulsion.inlet_performance import (
             DESIGN_ALTITUDE_M,
+            G0,
             MACH_DESIGN,
-            RamjetCycleAnalysis,
+            isa_atmosphere,
         )
 
-        analysis = RamjetCycleAnalysis()
+        analysis = GrzywkaCombustorNozzleAnalysis()
         analysis.setup(mach0=MACH_DESIGN, altitude_m=DESIGN_ALTITUDE_M)
         results = analysis.execute()
 
-        thrust_N = results["thrust_N"]
-        thrust_cylindrical_nozzle_N = results["thrust_cylindrical_nozzle_N"]
-        tsfc_kg_per_Ns = results["tsfc_kg_per_Ns"]
         mdot_fuel_kg_s = results["mdot_fuel_kg_s"]
-        v_cruise_ms = results.metadata["station_table"][0]["velocity_m_s"]
+        atmosphere = isa_atmosphere(DESIGN_ALTITUDE_M)
+        v_cruise_ms = MACH_DESIGN * atmosphere.speed_of_sound_m_s
 
-        cruise_time_s = fuel_mass_kg / mdot_fuel_kg_s
-        cruise_range_m = v_cruise_ms * cruise_time_s
+        thrust_scenarios: dict[str, dict[str, float]] = {}
+        for key, thrust_field, description in _THRUST_SCENARIOS:
+            scenario = _scenario_cruise_point(
+                thrust_N=results[thrust_field],
+                mdot_fuel_kg_s=mdot_fuel_kg_s,
+                fuel_mass_kg=fuel_mass_kg,
+                v_cruise_ms=v_cruise_ms,
+                g0_m_s2=G0,
+            )
+            scenario["description"] = description
+            thrust_scenarios[key] = scenario
+
+        nominal = thrust_scenarios["Th2"]  # real: combustor + nozzle losses
 
         return {
             "design_mach": MACH_DESIGN,
             "cruise_altitude_m": DESIGN_ALTITUDE_M,
-            "cruise_time_s": cruise_time_s,
-            "cruise_range_m": cruise_range_m,
+            "cruise_time_s": nominal["cruise_time_s"],
+            "cruise_range_m": nominal["cruise_range_m"],
             "fuel_mass_kg": fuel_mass_kg,  # SZACOWANY — placeholder fuel load
-            "thrust_N": thrust_N,
-            "thrust_cylindrical_nozzle_N": thrust_cylindrical_nozzle_N,
-            "tsfc_kg_per_Ns": tsfc_kg_per_Ns,
+            "thrust_N": nominal["thrust_N"],
+            "tsfc_kg_per_Ns": nominal["tsfc_kg_per_Ns"],
+            "isp_s": nominal["isp_s"],
             "mdot_fuel_kg_s": mdot_fuel_kg_s,
+            "thrust_scenarios": thrust_scenarios,
             "note": (
                 "Ramjet cruise: quasi-steady design point (Mach 2.5, "
                 "10,000 m ISA), NOT a trajectory ODE (fuel depletion, "
                 "drag and altitude/velocity coupling over time remain "
-                "TBD). thrust_N/tsfc_kg_per_Ns/mdot_fuel_kg_s from "
-                "analyses.propulsion.ramjet_cycle.RamjetCycleAnalysis "
-                "(matched design nozzle); thrust_cylindrical_nozzle_N is "
-                "the as-built Fusion CAD cylindrical-nozzle thrust, kept "
-                "alongside thrust_N so the CAD-vs-design discrepancy "
-                "stays visible. cruise_time_s = fuel_mass_kg / "
-                "mdot_fuel_kg_s and cruise_range_m = V_cruise * "
-                "cruise_time_s are DERIVED from the SZACOWANY 15 kg "
-                "fuel_mass_kg. Reference model: L2 1-D cycle, "
-                "single-method, MATLAB baseline unavailable, CFD delta "
-                "+20-30% open (see ramjet_cycle module docstring "
-                "'REFERENCE-MODEL DISCLOSURE')."
+                "TBD). thrust_N/tsfc_kg_per_Ns/isp_s/cruise_time_s/"
+                "cruise_range_m at the top level mirror the Th2 (real, "
+                "combustor+nozzle losses) scenario from "
+                "analyses.propulsion.combustor_nozzle_cycle."
+                "GrzywkaCombustorNozzleAnalysis. ALL THREE Grzywka Sec. "
+                "6.2.2 thrust scenarios (Thi ideal / Th1 combustor-loss-"
+                "only / Th2 real) are preserved, never collapsed, under "
+                "thrust_scenarios. mdot_fuel_kg_s is scenario-invariant "
+                "(same combustor mass flow/Tt1/Tt2/fuel-air ratio for all "
+                "three; only the delivered nozzle total pressure "
+                "differs), so cruise_time_s/cruise_range_m come out "
+                "numerically equal across scenarios at this constant-"
+                "Mach design point while thrust_N/tsfc_kg_per_Ns/isp_s "
+                "differ — see _scenario_cruise_point docstring. "
+                "cruise_time_s = fuel_mass_kg / mdot_fuel_kg_s and "
+                "cruise_range_m = V_cruise * cruise_time_s are DERIVED "
+                "from the SZACOWANY 15 kg fuel_mass_kg. Reference model: "
+                "L2 1-D Grzywka station cycle (1-2-21-3), single-method, "
+                "MATLAB baseline unavailable, CFD delta open (see "
+                "combustor_nozzle_cycle module docstring)."
             ),
         }
     except Exception as exc:  # noqa: BLE001 — deliberate graceful degradation


### PR DESCRIPTION
## Summary

Night-3 continuation of the ramP (Project B) nightly-run series. Resumes the Phase 2b Grzywka combustor+nozzle checkpoint that Night-2 left `BLOCKED_BY_BUDGET`, then unblocks the phases that depend on it.

Work is being landed incrementally as subagent phases complete; this PR will be updated as each phase finishes. Planned scope:

- **Phase 2b** (opus, propulsion-designer): `analyses/propulsion/combustor_nozzle_cycle.py` — Grzywka 2022 cycle, stations 1→2→21→3, dynamic D21 throat, three thrust models (Thi/Th1/Th2).
- **Phase 3b** (sonnet, mission-planner): wire `workflows/ramp_staged_mission.py` cruise design point to the Phase 2b output (Th2 nominal, all three scenarios preserved).
- **Phase 4b** (opus, propulsion-designer): movable-inlet actuation parameters in `analyses/propulsion/inlet_performance.py`.
- **Phase 5** (sonnet, aero-analyst): `doc/ramP/stability_reconciliation.md` — Barrowman vs Teltik CFD sign-flip analysis, read-only on vehicle configs.
- **Phase 6** (sonnet, aero-analyst): `analyses/cfd/su2_config_template.py` upgraded from stub to a Mach-sweep `.cfg` generator (no solver execution).
- **Docs**: tracker/assumptions/memory updates and a Night-3 nightly report.

## Test plan

- [ ] `python -m pytest tests/ -v --tb=short` green (80/80 baseline confirmed at session start after installing missing `scipy`/`numpy`/`pytest`/`pydantic`/`pyyaml` in the fresh container)
- [ ] New tests added per phase, all passing
- [ ] `doc/ramP/analysis_status.md` rows updated to DONE for completed phases
- [ ] No changes to `trunk/SUAVE/` or `core/` (rewrite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

---
_Generated by [Claude Code](https://claude.ai/code/session_019WwhUzm3DgGavsN59McGeW)_