### PR TITLE
chore(ramP): backlog wave 1 — dead-link audit + test docstrings (post-#12)

### DIFF
--- a/doc/ramP/analysis_status.md
+++ b/doc/ramP/analysis_status.md
@@ -23,7 +23,7 @@ Status legend: **DONE** (implemented + run) · **STUB** (scaffold + TODO) ·
 | 13 | Static margin review (Barrowman) | `doc/ramP/static_margin_review.md` | DONE | aero-analyst | 2026-07-08 |
 | 14 | Stability margin report (Barrowman vs Teltik 2024 CFD) | `doc/ramP/stability_margin_report.md` | DONE | aero-analyst | 2026-07-09 |
 | 15 | Inlet completeness audit (Night-2 Phase 1b) | `tests/unit/test_propulsion_inlet.py` | DONE | code-reviewer | 2026-07-09 |
-| 16 | Combustor+nozzle Grzywka model (CC→NT→NE, Thi/Th1/Th2) | `analyses/propulsion/combustor_nozzle_cycle.py` | **BLOCKED_BY_BUDGET** | propulsion-designer | 2026-07-09 |
+| 16 | Combustor+nozzle Grzywka model (CC→NT→NE, Thi/Th1/Th2) | `analyses/propulsion/combustor_nozzle_cycle.py` <!-- TODO: dead link, target missing as of 2026-07-09 --> | **BLOCKED_BY_BUDGET** | propulsion-designer | 2026-07-09 |
 | 17 | Cruise wiring to Grzywka model (Night-2 Phase 3b) | `workflows/ramp_staged_mission.py` | BLOCKED_BY_BUDGET | mission-planner | 2026-07-09 |
 | 18 | Movable-inlet actuation params (Night-2 Phase 4b) | `analyses/propulsion/inlet_performance.py` | BLOCKED_BY_BUDGET | propulsion-designer | 2026-07-09 |
 
@@ -38,8 +38,8 @@ clean, no partial/dangling files, full suite **80/80 tests green**.
 **Resume point:** next session should resume **Night-2 Phase 2b** from its
 full task spec below (do not re-diagnose, do not restart from Phase 0):
 
-- Create `analyses/propulsion/combustor_nozzle_cycle.py` +
-  `tests/unit/test_propulsion_combustor_nozzle.py`.
+- Create `analyses/propulsion/combustor_nozzle_cycle.py` <!-- TODO: dead link, target missing as of 2026-07-09 --> +
+  `tests/unit/test_propulsion_combustor_nozzle.py` <!-- TODO: dead link, target missing as of 2026-07-09 -->.
 - Model: Grzywka 2022, stations **1 → 2 → 21 → 3** (CC → NT → NE).
 - Loss coefficients: `pi_CC = 0.8924` (1→2), `pi_nozzle = 0.97` (2→3).
 - Nozzle throat area **D21 is dynamic** (a function of `V`, `H`), with

--- a/doc/ramP/preliminary_analysis_report.md
+++ b/doc/ramP/preliminary_analysis_report.md
@@ -74,7 +74,7 @@ DATCOM-style CD, mass depletion. Full data:
 > propellant over 6 s at Isp 207–230 s implies a **mean** thrust of ~25.4 kN — a peak below the
 > mean is impossible. The sim used the impulse-consistent 25.4 kN and ignored the 12 kN figure.
 
-![Boost phase](../../analyses/trajectory/boost_phase.png)
+![Boost phase](../../analyses/trajectory/boost_phase.png) <!-- TODO: dead link, target missing as of 2026-07-09 -->
 
 ---
 

--- a/tests/unit/test_propulsion_inlet.py
+++ b/tests/unit/test_propulsion_inlet.py
@@ -41,6 +41,7 @@ def test_isa_atmosphere_10km_matches_standard_values() -> None:
 
 
 def test_isa_atmosphere_rejects_negative_altitude() -> None:
+    """isa_atmosphere raises ValueError for negative altitude."""
     with pytest.raises(ValueError):
         isa_atmosphere(-1.0)
 
@@ -74,21 +75,25 @@ def test_normal_shock_total_pressure_ratio_decreases_with_mach() -> None:
 
 
 def test_mil_e_5007_eta_std_subsonic_is_unity() -> None:
+    """mil_e_5007_eta_std returns 1.0 for subsonic Mach."""
     assert mil_e_5007_eta_std(0.8) == 1.0
 
 
 def test_mil_e_5007_eta_std_at_mach_2p5() -> None:
+    """mil_e_5007_eta_std at Mach 2.5 returns ~0.8703, the MIL-E-5007 standard."""
     eta_std = mil_e_5007_eta_std(2.5)
     assert eta_std == pytest.approx(0.8703, abs=0.001)
 
 
 def test_inlet_performance_analysis_execute_before_setup_raises() -> None:
+    """InletPerformanceAnalysis.execute() raises RuntimeError if called before setup()."""
     analysis = InletPerformanceAnalysis()
     with pytest.raises(RuntimeError):
         analysis.execute()
 
 
 def test_inlet_performance_analysis_setup_rejects_subsonic_design_mach() -> None:
+    """InletPerformanceAnalysis.setup() raises ValueError for subsonic design Mach."""
     analysis = InletPerformanceAnalysis()
     with pytest.raises(ValueError):
         analysis.setup(mach_design=0.8)
@@ -221,12 +226,14 @@ def test_multi_cone_inlet_analysis_rejects_preset_for_2_and_3_cones() -> None:
 
 
 def test_multi_cone_inlet_analysis_execute_before_setup_raises() -> None:
+    """MultiConeInletPerformanceAnalysis.execute() raises RuntimeError if called before setup()."""
     analysis = MultiConeInletPerformanceAnalysis()
     with pytest.raises(RuntimeError):
         analysis.execute()
 
 
 def test_multi_cone_inlet_analysis_setup_rejects_bad_inputs() -> None:
+    """MultiConeInletPerformanceAnalysis.setup() rejects subsonic Mach, invalid n_cones, and eta_diffuser <= 0."""
     analysis = MultiConeInletPerformanceAnalysis()
     with pytest.raises(ValueError):
         analysis.setup(mach_design=0.8)
@@ -237,6 +244,7 @@ def test_multi_cone_inlet_analysis_setup_rejects_bad_inputs() -> None:
 
 
 def test_inlet_performance_analysis_mass_flow_scales_with_capture_area() -> None:
+    """Design-point mass flow scales linearly with inlet capture area."""
     analysis = InletPerformanceAnalysis()
     analysis.setup(mach_design=2.5, altitude_m=10_000.0, capture_area_m2=0.1)
     results = analysis.execute()

--- a/tests/unit/test_propulsion_ramjet_cycle.py
+++ b/tests/unit/test_propulsion_ramjet_cycle.py
@@ -38,6 +38,7 @@ def _independent_ideal_closed_form(mach0: float, altitude_m: float, tt4_K: float
 
 
 def test_stagnation_relations_at_zero_mach_are_identity() -> None:
+    """Stagnation temperature and pressure equal static values at Mach 0."""
     assert stagnation_temperature_K(300.0, 0.0, 1.4) == pytest.approx(300.0)
     assert stagnation_pressure_Pa(101325.0, 0.0, 1.4) == pytest.approx(101325.0)
 
@@ -56,28 +57,33 @@ def test_ideal_closed_form_matches_independent_hand_calc() -> None:
 
 
 def test_ideal_closed_form_rejects_non_supersonic_mach() -> None:
+    """ideal_ramjet_closed_form raises ValueError for Mach <= 1."""
     with pytest.raises(ValueError):
         ideal_ramjet_closed_form(0.8, DESIGN_ALTITUDE_M, TT4_DEFAULT_K)
 
 
 def test_ideal_closed_form_rejects_tt4_below_tt0() -> None:
+    """ideal_ramjet_closed_form raises ValueError when combustor temp below stagnation temp."""
     with pytest.raises(ValueError):
         ideal_ramjet_closed_form(MACH_DESIGN, DESIGN_ALTITUDE_M, 100.0)
 
 
 def test_execute_before_setup_raises() -> None:
+    """RamjetCycleAnalysis.execute() raises RuntimeError if called before setup()."""
     analysis = RamjetCycleAnalysis()
     with pytest.raises(RuntimeError):
         analysis.execute()
 
 
 def test_setup_rejects_subsonic_mach() -> None:
+    """RamjetCycleAnalysis.setup() raises ValueError for Mach <= 1."""
     analysis = RamjetCycleAnalysis()
     with pytest.raises(ValueError):
         analysis.setup(mach0=0.9)
 
 
 def test_setup_rejects_tt4_below_recovered_total_temperature() -> None:
+    """RamjetCycleAnalysis.setup() raises ValueError when combustor temp below stagnation temp."""
     analysis = RamjetCycleAnalysis()
     with pytest.raises(ValueError):
         analysis.setup(mach0=MACH_DESIGN, altitude_m=DESIGN_ALTITUDE_M, tt4_K=50.0)
@@ -85,6 +91,7 @@ def test_setup_rejects_tt4_below_recovered_total_temperature() -> None:
 
 @pytest.mark.parametrize("bad_eta_inlet", [0.0, -0.1, 1.5])
 def test_setup_rejects_bad_eta_inlet(bad_eta_inlet: float) -> None:
+    """RamjetCycleAnalysis.setup() raises ValueError for eta_inlet outside (0, 1)."""
     analysis = RamjetCycleAnalysis()
     with pytest.raises(ValueError):
         analysis.setup(eta_inlet=bad_eta_inlet)
@@ -92,6 +99,7 @@ def test_setup_rejects_bad_eta_inlet(bad_eta_inlet: float) -> None:
 
 @pytest.mark.parametrize("bad_pi_b", [0.0, -0.2, 1.2])
 def test_setup_rejects_bad_pi_b(bad_pi_b: float) -> None:
+    """RamjetCycleAnalysis.setup() raises ValueError for pi_b outside (0, 1)."""
     analysis = RamjetCycleAnalysis()
     with pytest.raises(ValueError):
         analysis.setup(pi_b=bad_pi_b)
@@ -99,12 +107,14 @@ def test_setup_rejects_bad_pi_b(bad_pi_b: float) -> None:
 
 @pytest.mark.parametrize("bad_eta_b", [0.0, -0.2, 1.2])
 def test_setup_rejects_bad_eta_b(bad_eta_b: float) -> None:
+    """RamjetCycleAnalysis.setup() raises ValueError for eta_b outside (0, 1)."""
     analysis = RamjetCycleAnalysis()
     with pytest.raises(ValueError):
         analysis.setup(eta_b=bad_eta_b)
 
 
 def test_design_point_fuel_air_ratio_in_expected_range() -> None:
+    """Design-point fuel-to-air ratio falls in (0, 0.068), a reasonable ramjet band."""
     analysis = RamjetCycleAnalysis()
     analysis.setup(mach0=MACH_DESIGN, altitude_m=DESIGN_ALTITUDE_M, tt4_K=TT4_DEFAULT_K)
     results = analysis.execute()
@@ -112,6 +122,7 @@ def test_design_point_fuel_air_ratio_in_expected_range() -> None:
 
 
 def test_design_point_fidelity_is_level_2() -> None:
+    """RamjetCycleAnalysis results are marked as FidelityLevel.LEVEL_2."""
     analysis = RamjetCycleAnalysis()
     analysis.setup()
     results = analysis.execute()
@@ -119,6 +130,7 @@ def test_design_point_fidelity_is_level_2() -> None:
 
 
 def test_design_point_thrust_positive_and_cylindrical_below_matched() -> None:
+    """Matched nozzle thrust exceeds CAD cylindrical nozzle; both positive."""
     analysis = RamjetCycleAnalysis()
     analysis.setup(mach0=MACH_DESIGN, altitude_m=DESIGN_ALTITUDE_M, tt4_K=TT4_DEFAULT_K)
     results = analysis.execute()
@@ -157,6 +169,7 @@ def test_losses_reduce_thrust_and_raise_tsfc_vs_loss_free_reference() -> None:
 
 
 def test_validate_results_passes_on_design_point() -> None:
+    """validate_results() returns True for a valid design-point execution."""
     analysis = RamjetCycleAnalysis()
     analysis.setup(mach0=MACH_DESIGN, altitude_m=DESIGN_ALTITUDE_M, tt4_K=TT4_DEFAULT_K)
     results = analysis.execute()
@@ -173,6 +186,7 @@ def test_eta_inlet_default_matches_four_cone_preset_value() -> None:
 
 
 def test_eta_inlet_override_is_respected() -> None:
+    """setup() applies the user-provided eta_inlet override in results."""
     analysis = RamjetCycleAnalysis()
     analysis.setup(mach0=MACH_DESIGN, altitude_m=DESIGN_ALTITUDE_M, eta_inlet=0.5)
     results = analysis.execute()
@@ -180,6 +194,7 @@ def test_eta_inlet_override_is_respected() -> None:
 
 
 def test_station_table_has_expected_stations() -> None:
+    """Metadata station_table contains all required cycle stations."""
     analysis = RamjetCycleAnalysis()
     analysis.setup()
     results = analysis.execute()
@@ -194,6 +209,7 @@ def test_station_table_has_expected_stations() -> None:
 
 
 def test_mass_flow_positive_and_fuel_less_than_air() -> None:
+    """Design-point mass flows are positive and fuel < air (stoichiometric limit)."""
     analysis = RamjetCycleAnalysis()
     analysis.setup()
     results = analysis.execute()
@@ -202,6 +218,7 @@ def test_mass_flow_positive_and_fuel_less_than_air() -> None:
 
 
 def test_isp_consistent_with_thrust_and_fuel_flow() -> None:
+    """Isp equals thrust / (mdot_fuel * g0), verifying thrust-flow consistency."""
     analysis = RamjetCycleAnalysis()
     analysis.setup()
     results = analysis.execute()


### PR DESCRIPTION
# Pull Request Checklist
 * **Latest develop merged in:** branch rebased onto `origin/develop` HEAD (`5593546a`, the PR #12 merge) — single commit `91f12915` on top.
 * **.pyc files:** none committed.
 * **Regression run:** `python -m pytest tests/ -v --tb=short` → **80/80 passed** after rebase.
 * **New regression tests:** n/a — docstring-only edits to existing tests (25 one-line docstrings added; zero logic changes) plus dead-link TODO markers in `doc/` Markdown.
 * **Docstrings updated:** yes — that is the substance of this PR (test-function docstrings).
 * **Headers:** unchanged; no new files.
 * **Final compare vs develop:** touches only `tests/unit/test_propulsion_inlet.py`, `tests/unit/test_propulsion_ramjet_cycle.py`, `doc/ramP/preliminary_analysis_report.md`, `doc/ramP/analysis_status.md` (TODO markers on 3 dead internal references).

## Summary
Post-merge cleanup wave from the Night-2 session backlog (B1 dead-link audit, B2 test docstrings), rebased onto develop after PR #12 merged.

⚠️ Coordination note: a parallel Night-3 session is active on `claude/dazzling-turing-d91coa` (its PR will touch `doc/ramP/analysis_status.md` too — trivial marker-level conflicts possible; merge that PR first if in doubt, these TODO markers can be re-applied).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017iJtmiqXtxDbFem2ayY1qG

---
_Generated by [Claude Code](https://claude.ai/code/session_017iJtmiqXtxDbFem2ayY1qG)_