### PR TITLE
docs: Phase 1 IADE repo-separation plan (ADR-001 + migration plan)

### DIFF
--- a/docs/ADR/ADR-001-repo-separation.md
+++ b/docs/ADR/ADR-001-repo-separation.md
@@ -1,0 +1,123 @@
+# ADR-001 — Separate MELprop-IADE from the embedded SUAVE fork
+
+- **Status:** Proposed (Phase 1 planning artifact — filter-repo not yet executed)
+- **Date:** 2026-07-09
+- **Deciders:** KNN MELprop human review (decisions logged 2026-07-09), agent (planning only)
+- **Related:** `docs/migration-plan-phase1.md`, `docs/decision-log.md`, `docs/assumptions.md`
+
+## Context
+
+`knnmelprop/droneEnv` is a fork of SUAVE (suavecode/SUAVE) with MELprop's
+IADE work (Project A — GTM-140 drone, Project B — ramP rocket) grafted on
+top. Verified facts as of this ADR (branch `claude/iade-repo-restructure-00rrro`,
+commit `a0a1b034`):
+
+- **790 commits total**, history starting 2019-03-13 (`8a5a870b`, a SUAVE
+  upstream merge). Top committers by count: Racheal Erhard (140), Matthew
+  Clarke (135), "planes" (125), Emilio Botero (89), mclarke2 (67), **Claude
+  (52)**, Sof222 (41), Aleks Czernicki (26), plus several more SUAVE upstream
+  authors. The overwhelming majority of history is SUAVE upstream, not
+  MELprop-authored.
+- `.git` is **124 MB**; the `regression/` working tree alone is **311 MB**
+  (359 files) — SUAVE's own regression-test corpus, referenced by
+  `appveyor.yml` (`cd ../regression && coverage run automatic_regression.py`),
+  not MELprop-owned.
+- Embedded upstream trees still present: `trunk/` (6.5 MB, real vendored
+  SUAVE source + `setup.py`/`MANIFEST.in`), `SUAVE/` (8 KB namespace stub
+  shadowing `trunk/SUAVE` so bare `import SUAVE` resolves), `Tutorials-2.3.1/`
+  (380 KB), `Tutorials252/` (516 KB), `ide/` (8 KB, 1 file), `templates/`
+  (48 KB, 7 files) — all SUAVE tutorial/example artifacts.
+- `student_competition/` (368 KB, 33 files) is **MELprop-owned** (Droniada
+  Sztafeta framework, merged from the former `droniada` branch per
+  `doc/AGENT_CONTEXT.md` §1) — it is *not* upstream baggage despite living
+  alongside the SUAVE tutorial trees, and must not be dropped by the same
+  extraction pass that removes `Tutorials*`/`ide`/`templates`/`regression`.
+- `appveyor.yml` is SUAVE's Windows/AppVeyor CI config (installs into
+  `trunk`, runs `regression/`) and **contains a plaintext-looking
+  `COVERALLS_REPO_TOKEN` value**. It is upstream baggage scheduled for
+  removal in this extraction regardless; flagging here because purging it
+  from history also purges that token. Whether the token is still live is
+  outside this agent's ability to check — recommend treating it as
+  compromised and rotating/revoking on the Coveralls side if it is still
+  active, independent of the repo-separation work.
+- Two doc trees currently coexist: legacy `doc/` (from the SUAVE-tutorial
+  era: `AGENT_CONTEXT.md`, `ramP/`, `segments/`, `data/`, `suave_logo.png`,
+  a duplicate `PULL_REQUEST_TEMPLATE.md`) and new `docs/` (MELprop's
+  `assumptions.md`, `decision-log.md`). 18 files reference `doc/` by path
+  (README.md, CLAUDE.md, `.gitignore`, `agents/memory.md`,
+  `docs/{assumptions,decision-log}.md`, `.claude/agents/docs-writer.md`,
+  `.claude/agent-memory/docs-writer/MEMORY.md`, and several
+  `analyses/`/`workflows/`/`tests/` modules) — consolidating requires a
+  path move **and** a reference-fixing pass, not just `git mv doc docs`.
+
+## Decision
+
+1. Extract only IADE-owned paths from history using `git filter-repo` with
+   a path allowlist (see `migration-plan-phase1.md`), executed against a
+   **disposable clone**, never the working copy directly — and only after
+   the human-confirmed backup mirror (already created, per human review) is
+   verified reachable by whoever runs the command.
+2. Consolidate `doc/` → `docs/` via `git mv` **as its own commit**, on the
+   current branch, *before* the filter-repo pass, with a follow-up commit
+   fixing the 18 known cross-references. This keeps blame/history for the
+   moved files intact (`git mv` + normal commit, not filter-repo) and keeps
+   the filter-repo pass simpler (single `docs/` path instead of `doc/` +
+   `docs/`).
+3. Deduplicate `PULL_REQUEST_TEMPLATE.md`: keep the root copy, delete
+   `doc/PULL_REQUEST_TEMPLATE.md` in the same consolidation commit.
+4. `SUAVE` stops being the repo's identity. `trunk/SUAVE` is pinned
+   **exactly at its currently-embedded commit** (no version bump — human
+   decision) and will move to `external/suave/` as a submodule in Phase 2;
+   it is dropped from the extracted history in this phase, not carried
+   forward as vendored source.
+5. `pyCycle` is pinned to tag `4.1.2` (submodule ref) with a matching
+   `om-pycycle==4.1.2` runtime pin (Phase 2 — recorded here so Phase 2
+   doesn't have to re-derive it).
+6. AVL, XFOIL, SU2, OpenVSP pins are **explicitly deferred** to Phase 2+.
+   `knnmelprop/avl-mirror` and `knnmelprop/xfoil-mirror` exist as
+   intentionally-empty placeholder repos; they will be populated with
+   upstream source only after a license review, in a future phase. This is
+   a logged decision, not an oversight.
+7. `LICENSE` (SUAVE's LGPL-2.1 text) is **left as-is** in this phase. The
+   target IADE license (**PolyForm Noncommercial 1.0.0**) is recorded here
+   as a forward-looking intent only — it is **not applied** until a
+   separate, explicit licensing decision is made (this ADR does not
+   authorize a license change).
+8. `ide/`, `templates/`, `regression/`, `appveyor.yml` are treated as
+   upstream SUAVE baggage and **excluded** from the owned-path allowlist
+   (same bucket as `SUAVE/`, `trunk/`, `Tutorials*`).
+9. `student_competition/` and `conftest.py` are treated as **MELprop-owned**
+   and **added** to the owned-path allowlist (not on the literal list given
+   in the original task framing, but dropping either would destroy real
+   MELprop work — `student_competition/` — or silently break every pytest
+   run — `conftest.py`, which is what makes the repo root importable for
+   the whole `tests/` suite). `.devcontainer/` is likewise kept: it is
+   explicitly named in the target top-level structure and will be reworked
+   (not removed) in Phase 3.
+
+## Consequences
+
+- Most of the repo's 790-commit history (SUAVE upstream authorship) is
+  **not preserved** in the new `knnmelprop/iade` repo after extraction —
+  accepted per human decision ("loss of part of the old history is
+  acceptable if the result is a cleaner independent IADE repo").
+- The AppVeyor Coveralls token disappears from the extracted history as a
+  side effect of dropping `appveyor.yml`; it is **not** independently
+  purged from `knnmelprop/droneEnv`'s existing history — that repo is left
+  as-is per "do not rewrite history until explicitly told."
+- Until Phase 2, the new `knnmelprop/iade` repo will have no SUAVE, AVL,
+  XFOIL, pyCycle, SU2, or OpenVSP present at all — it will not run
+  SUAVE-dependent analyses out of the box. This is expected and matches
+  the phased plan.
+- The `doc/` → `docs/` consolidation touches 18 files outside `doc/`
+  itself; this is real, reviewable work and is called out as a discrete
+  step in the migration plan rather than folded silently into filter-repo.
+
+## Open questions carried forward (not decided here)
+
+- Final IADE license mode/date (PolyForm Noncommercial 1.0.0 intent noted,
+  not applied).
+- Whether the (possibly dead) Coveralls token needs rotation on the
+  service side.
+- Exact `external/` submodule wiring and pinned refs for AVL/XFOIL/SU2/
+  OpenVSP (Phase 2).

--- a/docs/migration-plan-phase1.md
+++ b/docs/migration-plan-phase1.md
@@ -1,0 +1,191 @@
+# Phase 1 — History Extraction Plan
+
+Status: **planning only — nothing in this file has been executed.**
+No `git mv`, no `git filter-repo`, no push has happened yet. See
+`docs/ADR/ADR-001-repo-separation.md` for the reasoning behind each
+inclusion/exclusion decision below.
+
+Source repo: `knnmelprop/droneEnv`, branch `claude/iade-repo-restructure-00rrro`
+@ `a0a1b034`. Target repo: `knnmelprop/iade` (confirmed empty, 0 commits).
+Backup: human-confirmed local `git clone --mirror` taken before this run —
+**not independently re-verified by the agent**, per instruction.
+
+---
+
+## Step A — Pre-filter cleanup (run in-place on the current branch, normal commits)
+
+These are ordinary, reversible commits on `droneEnv` itself — no history
+rewrite, no filter-repo. They must land **before** Step B so the filter-repo
+path allowlist only has to name `docs/`, not `doc/` + `docs/`.
+
+1. **Consolidate `doc/` → `docs/`** via `git mv doc/* docs/` (preserves
+   per-file history/blame). Merges in: `AGENT_CONTEXT.md`, `ramP/` (9 files),
+   `segments/`, `data/`, `1_README.md`, `suave_logo.png`, `suave_config`,
+   `git_branching.txt`.
+   - Delete `doc/PULL_REQUEST_TEMPLATE.md` (keep root `PULL_REQUEST_TEMPLATE.md`
+     only — human decision #4).
+   - Fix the 18 known cross-references to `doc/` in the same or an
+     immediately-following commit: `README.md`, `CLAUDE.md`, `.gitignore`
+     (`/doc/html`, `/doc/latex`, `!/doc/suave_logo.png` → `/docs/...`),
+     `agents/memory.md`, `docs/assumptions.md`, `docs/decision-log.md`,
+     `.claude/agents/docs-writer.md`, `.claude/agent-memory/docs-writer/MEMORY.md`,
+     and code references in `analyses/aero/barrowman_extended.py`,
+     `analyses/trajectory/booster_burnout.py`, `analyses/cfd/su2_config_template.py`,
+     `workflows/ramp_staged_mission.py`, `tests/unit/test_barrowman_extended.py`,
+     `tests/unit/test_trajectory_launch_angle.py`,
+     `analyses/aero/results/SM_sensitivity_fin_span.csv` (data file — verify
+     whether the `doc/` string there is a path reference or incidental text
+     before editing).
+   - Run `python -m pytest tests/ -v --tb=short` — must stay at 208/208
+     before committing (project rule #8 / "never commit if tests are red").
+2. Commit message convention: `docs: consolidate doc/ into docs/, fix cross-references`.
+
+**This step is not executed yet.** It requires its own go-ahead the same as
+Step B, since it touches 18+ files even though each change is low-risk.
+
+---
+
+## Step B — History extraction (git filter-repo, disposable clone only)
+
+### Owned paths (kept)
+
+Per the explicit Phase-1 scope, **plus** two additions justified in
+ADR-001 (`student_competition/`, `conftest.py` — both MELprop-owned/required,
+not on the original literal list but dropping either destroys real work or
+breaks every test collection):
+
+```
+core/
+src/
+vehicles/
+analyses/
+workflows/
+agents/
+.claude/
+docs/
+tests/
+student_competition/      # ADDED — MELprop-owned (Droniada Sztafeta), not SUAVE baggage
+CLAUDE.md
+README.md
+.gitignore
+INSTALL
+conftest.py               # ADDED — required for tests/ to import repo root
+LICENSE                   # kept as-is per human decision #5 (left untouched)
+PULL_REQUEST_TEMPLATE.md  # root copy only, after Step A dedup
+.devcontainer/            # kept per target structure; reworked (not removed) in Phase 3
+```
+
+### Removed from history (upstream/vendor baggage)
+
+```
+SUAVE/            # namespace stub shadowing trunk/SUAVE
+trunk/            # vendored SUAVE source (setup.py, MANIFEST.in, trunk/SUAVE/)
+Tutorials-2.3.1/
+Tutorials252/
+ide/              # SUAVE IDE-plugin readme, 1 file
+templates/        # SUAVE example templates, 7 files
+regression/       # SUAVE regression-test corpus, 311 MB / 359 files
+appveyor.yml      # SUAVE Windows/AppVeyor CI config (also drops the embedded Coveralls token, see ADR-001)
+```
+
+### ⚠️ Not yet classified — do not run the command until these are resolved
+
+Everything above is either explicitly given or has an unambiguous
+justification. Nothing else in the repo root was on either list from the
+original task framing. Re-scanning the current tree turned up no further
+unclassified top-level paths — the two lists above now account for every
+top-level entry. **This section is intentionally empty after ADR-001's
+additions; kept as a placeholder so a future re-run of this plan doesn't
+skip the check.**
+
+### Exact command block (for human approval — NOT executed)
+
+```bash
+# 1. Take a disposable working clone — never run filter-repo on the
+#    directory anyone is actively using, and never on the backup mirror.
+git clone /home/user/droneEnv /home/user/iade-extraction-work
+cd /home/user/iade-extraction-work
+
+# 2. Confirm Step A (doc/ -> docs/ consolidation) has already landed on
+#    the branch being cloned, and that pytest is green, before proceeding.
+python -m pytest tests/ -v --tb=short
+
+# 3. Run the extraction. --force is required because this is a clone with
+#    an `origin` remote already set; filter-repo insists on this flag
+#    precisely to stop accidental in-place runs.
+git filter-repo --force \
+  --path core \
+  --path src \
+  --path vehicles \
+  --path analyses \
+  --path workflows \
+  --path agents \
+  --path .claude \
+  --path docs \
+  --path tests \
+  --path student_competition \
+  --path CLAUDE.md \
+  --path README.md \
+  --path .gitignore \
+  --path INSTALL \
+  --path conftest.py \
+  --path LICENSE \
+  --path PULL_REQUEST_TEMPLATE.md \
+  --path .devcontainer
+
+# 4. Inspect the result BEFORE pushing anywhere:
+git log --oneline | wc -l          # expect << 790; report exact number
+git log --diff-filter=A --name-only --pretty=format: | sort -u > /tmp/kept_files.txt
+wc -l /tmp/kept_files.txt          # sanity check against expected owned set
+du -sh .git                        # expect well under the current 124 MB
+
+# 5. STOP. Do not add a remote / push to knnmelprop/iade yet — that is a
+#    separate, explicit approval gate per the task's hard constraints
+#    ("do not push rewritten history until explicitly told").
+```
+
+### Stop conditions during execution (per project stop rules)
+
+If any of these occur, halt and report instead of improvising:
+- `git filter-repo` exits non-zero or reports an unexpected empty result set.
+- Post-filter `git log --oneline | wc -l` is 0 or implausibly small/large.
+- `pytest` collection count in the filtered clone differs from 208 (the
+  verified current baseline) once `PYTHONPATH`/deps are restored.
+- Any of the 18 cross-reference fixes from Step A turn out to be
+  incomplete when re-checked in the filtered clone (broken links to
+  `docs/ramP/...` are a signal Step A wasn't fully applied first).
+
+---
+
+## Validation checklist (post-filter, pre-push)
+
+- [ ] `git log --oneline | wc -l` reported and sane (expect roughly the
+      number of MELprop-authored commits touching owned paths — likely a
+      small fraction of 790; exact number depends on how filter-repo
+      collapses empty commits, report it rather than assume).
+- [ ] `du -sh .git` shrunk substantially from 124 MB (the 311 MB
+      `regression/` and 6.5 MB `trunk/` should no longer be reachable in
+      any historical blob).
+- [ ] `python -m pytest tests/ -v --tb=short` → 208 passed, 0 failed, in
+      the filtered clone (after reinstalling `pydantic>=2, pyyaml, pytest,
+      scipy, matplotlib`).
+- [ ] No remaining `import SUAVE` / `trunk.SUAVE` references resolve
+      ambiguously (guarded imports in `core/` should simply report SUAVE
+      unavailable, as they already do — verified this run via
+      `test_probe_suave_available_is_false_in_this_container`).
+- [ ] No `.gitignore` or doc cross-reference still points at `doc/`
+      (should already be zero if Step A ran first).
+- [ ] `docs/decision-log.md` gets an entry recording the filter-repo run
+      (commit count before/after, `.git` size before/after, timestamp).
+
+---
+
+## Explicitly out of scope for this phase (confirmed by human review)
+
+- No `external/` submodules wired yet (Phase 2).
+- No AVL/XFOIL/SU2/OpenVSP pins (deferred to Phase 2+, logged in ADR-001).
+- `avl-mirror` / `xfoil-mirror` stay empty (logged as intentional
+  placeholders, human decision #3).
+- No push to `knnmelprop/iade` (separate approval gate).
+- No license file changes (human decision #5 — PolyForm Noncommercial
+  1.0.0 is a forward-looking note in ADR-001 only).


### PR DESCRIPTION
## Summary

Planning-only deliverables for Phase 1 of the MELprop-IADE repo restructure
(separating IADE from the embedded SUAVE fork). No history rewrite, no
submodule wiring, and no push to the target `knnmelprop/iade` repo has
happened — this PR only adds two documents to `knnmelprop/droneEnv`.

- `docs/ADR/ADR-001-repo-separation.md` — records the human-reviewed
  decisions: backup mirror confirmed, pinned refs (SUAVE = current
  `trunk/` commit as-is, pyCycle = tag `4.1.2`), AVL/XFOIL/SU2/OpenVSP
  pins deferred to Phase 2+ with `avl-mirror`/`xfoil-mirror` logged as
  intentional empty placeholders, `doc/` → `docs/` consolidation approach,
  and license handling (LGPL-2.1 left as-is; PolyForm Noncommercial 1.0.0
  noted only as a forward-looking intent, not applied).
- `docs/migration-plan-phase1.md` — a two-step plan: Step A (ordinary
  commits: `doc/`→`docs/` `git mv`, `PULL_REQUEST_TEMPLATE.md` dedup, fix
  18 cross-references) and Step B (the exact `git filter-repo` command,
  owned-path allowlist, and post-run validation checklist), gated behind a
  separate human approval before execution.

## Test plan

- [x] `python -m pytest tests/ -v --tb=short` — 208 passed, 0 failed
      (baseline unchanged; this PR is docs-only, no source files touched)
- [ ] Human review of ADR-001 and the migration plan before Step A/Step B
      are executed in a follow-up PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_014m9gVGqubzD6hCtGW2qgt4)_